### PR TITLE
ci: page CI Pass check by name in release verify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,7 +331,10 @@ jobs:
           # run on that branch. The full extension matrix is a separate
           # release-time gate (the `full-matrix-build` job in this
           # workflow) since it only matters when we ship.
-          status=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs" \
+          # NOTE: filter API-side via ?check_name= because a release SHA
+          # can easily exceed the default 30-result page (full matrix +
+          # release jobs all attach checks to the tagged commit).
+          status=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs?check_name=CI+Pass&per_page=100" \
             --jq '[.check_runs[] | select(.name == "CI Pass")] | .[0].conclusion // "missing"')
           echo "ci-pass status at $SHA: $status"
           if [[ "$status" != "success" ]]; then


### PR DESCRIPTION
## Summary
- The release workflow's "Verify day-to-day CI is green at the release SHA" step queried `/commits/{sha}/check-runs` with no paging or filter, so on release SHAs the `CI Pass` aggregator could fall outside the default 30-result page and look "missing" even when green.
- Fix: filter API-side with `?check_name=CI+Pass&per_page=100` so the aggregator is found deterministically.

## Why this is needed now
- The `v0.1.0` dispatch (run [25155637108](https://github.com/ekkuleivonen/ducklake-cdc-extension/actions/runs/25155637108)) failed at exactly this step on the post-PR-#2 merge commit `8e57fde`, even though `CI Pass` was green at that SHA — there were 48 check-runs at the SHA, and `CI Pass` lived on page 2.

## Test plan
- [x] Confirmed `gh api repos/.../commits/8e57fde/check-runs?check_name=CI+Pass` returns the green `CI Pass` aggregator.
- [ ] After merge, re-trigger the `v0.1.0` release dispatch with `dry_run=false` and watch the verify step pass.

Made with [Cursor](https://cursor.com)