### PR TITLE
Finalize hot-path benchmark sweep

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -85,6 +85,10 @@ jobs:
             --runtime official \
             --cdc-extension build/benchmark/extensions/ducklake_cdc.duckdb_extension \
             --workload bench/light.yaml
+          uv run --locked python bench/runner.py \
+            --runtime official \
+            --cdc-extension build/benchmark/extensions/ducklake_cdc.duckdb_extension \
+            --workload bench/empty-window.yaml
 
       - name: Upload benchmark result
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -509,6 +509,9 @@ jobs:
           path = Path(os.environ["DESCRIPTOR"])
           version = os.environ["STRIPPED_VERSION"]
           sha = os.environ["RELEASE_SHA"]
+          community_test_config = (
+              "  test_config: '{\"test_env_variables\":{\"LINUX_CI_IN_DOCKER\":\"0\"}}'"
+          )
 
           text = path.read_text()
           text = re.sub(
@@ -523,6 +526,13 @@ jobs:
               text,
               count=1,
           )
+          if "test_config:" not in text:
+              text = re.sub(
+                  r'(?m)^(\s*requires_toolchains:\s*.*)$',
+                  lambda m: f"{m.group(1)}\n{community_test_config}",
+                  text,
+                  count=1,
+              )
           path.write_text(text)
           PY
           else
@@ -536,6 +546,7 @@ jobs:
             license: Apache-2.0
             excluded_platforms: ""
             requires_toolchains: ""
+            test_config: '{"test_env_variables":{"LINUX_CI_IN_DOCKER":"0"}}'
             maintainers:
               - "$ACTOR"
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -14,8 +14,11 @@ uv run --locked python bench/runner.py \
 ```
 
 `bench/light.yaml` is intentionally short: a 60-second flat profile,
-0.5 target snapshots/second, 100 target rows/snapshot, one consumer. The
-runner accepts command-line overrides for the same fields so local
+0.5 target snapshots/second, 100 target rows/snapshot, one consumer.
+`bench/empty-window.yaml` keeps the same producer shape but adds four
+empty `cdc_window` probes after each committed non-empty window, so 80%
+of window calls measure the steady-state "consumer already at head" path.
+The runner accepts command-line overrides for the same fields so local
 experiments can run faster:
 
 ```sh
@@ -30,7 +33,8 @@ top-level `result_schema_version` makes future result history comparable.
 The schema separates the configured workload from observed measurements:
 
 - `workload`: stable input envelope (`load_profile`, duration, target
-  snapshots/second, target rows/snapshot, consumers, max snapshots).
+  snapshots/second, target rows/snapshot, consumers, max snapshots, and
+  optional empty-window ratio).
 - `measurements`: observed duration, produced/consumed counts, actual
   rates, end-to-end latency summary, CDC call counts, catalog QPS, lag,
   and per-operation timing summaries where the runtime can collect them.

--- a/bench/empty-window.yaml
+++ b/bench/empty-window.yaml
@@ -1,0 +1,8 @@
+name: empty-window
+load_profile: flat
+duration_seconds: 60
+target_snapshots_per_second: 0.5
+target_rows_per_snapshot: 100
+consumers: 1
+max_snapshots: 100
+empty_window_ratio: 0.8

--- a/bench/runner.py
+++ b/bench/runner.py
@@ -253,6 +253,7 @@ class Workload:
     target_rows_per_snapshot: int
     consumers: int
     max_snapshots: int
+    empty_window_ratio: float = 0.0
 
 
 def parse_flat_yaml(path: Path) -> dict[str, str]:
@@ -290,6 +291,7 @@ def load_workload(path: Path, args: argparse.Namespace) -> Workload:
         target_rows_per_snapshot=target_rows_per_snapshot,
         consumers=int(raw["consumers"]),
         max_snapshots=int(raw["max_snapshots"]),
+        empty_window_ratio=float(raw.get("empty_window_ratio", "0")),
     )
     for field_name in (
         "duration_seconds",
@@ -297,6 +299,7 @@ def load_workload(path: Path, args: argparse.Namespace) -> Workload:
         "target_rows_per_snapshot",
         "consumers",
         "max_snapshots",
+        "empty_window_ratio",
     ):
         override = getattr(args, field_name)
         if override is not None:
@@ -314,6 +317,8 @@ def load_workload(path: Path, args: argparse.Namespace) -> Workload:
         or workload.max_snapshots <= 0
     ):
         raise ValueError("all numeric workload parameters must be positive")
+    if workload.empty_window_ratio < 0 or workload.empty_window_ratio >= 1:
+        raise ValueError("empty_window_ratio must be >= 0 and < 1")
     return workload
 
 
@@ -418,12 +423,15 @@ def timed_execute(conn: Any, sql: str, samples_ms: list[float]) -> Any:
         samples_ms.append((now_nanos() - started_ns) / 1000000.0)
 
 
-def timed_fetchall(conn: Any, sql: str, samples_ms: list[float]) -> list[Any]:
+def timed_fetchall(conn: Any, sql: str, samples_ms: list[float], extra_samples_ms: list[float] | None = None) -> list[Any]:
     started_ns = now_nanos()
     try:
         return require_ok_python(conn, sql).fetchall()
     finally:
-        samples_ms.append((now_nanos() - started_ns) / 1000000.0)
+        elapsed_ms = (now_nanos() - started_ns) / 1000000.0
+        samples_ms.append(elapsed_ms)
+        if extra_samples_ms is not None:
+            extra_samples_ms.append(elapsed_ms)
 
 
 def values_for_snapshot(snapshot_index: int, rows_per_snapshot: int, produced_ns: int) -> str:
@@ -432,6 +440,12 @@ def values_for_snapshot(snapshot_index: int, rows_per_snapshot: int, produced_ns
         event_id = (snapshot_index * rows_per_snapshot) + row
         values.append(f"({event_id}, {produced_ns}, {snapshot_index}, {row})")
     return "INSERT INTO lake.bench_events VALUES " + ", ".join(values)
+
+
+def empty_window_probes_per_non_empty(workload: Workload) -> int:
+    if workload.empty_window_ratio <= 0:
+        return 0
+    return max(1, round(workload.empty_window_ratio / (1.0 - workload.empty_window_ratio)))
 
 
 def require_ok_python(conn: Any, sql: str) -> Any:
@@ -466,14 +480,18 @@ def run_python_benchmark(cdc_extension: Path, workload: Workload, tmpdir: Path) 
     end_to_end_latencies_ms: list[float] = []
     producer_insert_ms: list[float] = []
     cdc_window_ms: list[float] = []
+    cdc_window_empty_ms: list[float] = []
     cdc_changes_ms: list[float] = []
     cdc_commit_ms: list[float] = []
     consumed_events = 0
     cdc_window_calls = 0
+    cdc_window_non_empty_calls = 0
+    cdc_window_empty_calls = 0
     cdc_changes_calls = 0
     cdc_commit_calls = 0
     producer_inserts = 0
     produced_rows = 0
+    empty_probes_per_non_empty = empty_window_probes_per_non_empty(workload)
     started_at = time.monotonic()
 
     for snapshot in range(planned_snapshots):
@@ -501,6 +519,7 @@ def run_python_benchmark(cdc_extension: Path, workload: Workload, tmpdir: Path) 
                 cdc_window_ms,
             )
             cdc_window_calls += 1
+            cdc_window_non_empty_calls += 1
             if len(window_rows) != 1 or not window_rows[0][2]:
                 raise RuntimeError(f"expected a non-empty cdc_window for {consumer_name}")
             end_snapshot = window_rows[0][1]
@@ -532,6 +551,20 @@ def run_python_benchmark(cdc_extension: Path, workload: Workload, tmpdir: Path) 
             )
             cdc_commit_calls += 1
 
+            for _ in range(empty_probes_per_non_empty):
+                empty_window_rows = timed_fetchall(
+                    conn,
+                    "SELECT * FROM cdc_window('lake', "
+                    + quote_string(consumer_name)
+                    + f", max_snapshots => {workload.max_snapshots})",
+                    cdc_window_ms,
+                    cdc_window_empty_ms,
+                )
+                cdc_window_calls += 1
+                cdc_window_empty_calls += 1
+                if len(empty_window_rows) != 1 or empty_window_rows[0][2]:
+                    raise RuntimeError(f"expected an empty cdc_window for {consumer_name}, got {empty_window_rows!r}")
+
     actual_duration_seconds = time.monotonic() - started_at
     catalog_queries_estimated = cdc_window_calls + cdc_changes_calls + cdc_commit_calls
 
@@ -553,6 +586,7 @@ def run_python_benchmark(cdc_extension: Path, workload: Workload, tmpdir: Path) 
         "operation_ms": {
             "producer_insert": metric_summary(producer_insert_ms),
             "cdc_window": metric_summary(cdc_window_ms),
+            "cdc_window_empty": metric_summary(cdc_window_empty_ms),
             "cdc_changes": metric_summary(cdc_changes_ms),
             "cdc_commit": metric_summary(cdc_commit_ms),
         },
@@ -560,6 +594,11 @@ def run_python_benchmark(cdc_extension: Path, workload: Workload, tmpdir: Path) 
         "catalog_qps_avg": catalog_queries_estimated / actual_duration_seconds,
         "lag_snapshots_max": 0,
         "cdc_window_calls": cdc_window_calls,
+        "cdc_window_non_empty_calls": cdc_window_non_empty_calls,
+        "cdc_window_empty_calls": cdc_window_empty_calls,
+        "empty_window_ratio": (
+            cdc_window_empty_calls / cdc_window_calls if cdc_window_calls > 0 else 0.0
+        ),
         "cdc_changes_calls": cdc_changes_calls,
         "cdc_commit_calls": cdc_commit_calls,
     }
@@ -623,6 +662,9 @@ def normalize_legacy_measurements(measurements: dict[str, Any], workload: Worklo
         "catalog_qps_avg": float(measurements["catalog_qps_avg"]),
         "lag_snapshots_max": int(measurements["lag_snapshots_max"]),
         "cdc_window_calls": int(measurements["cdc_window_calls"]),
+        "cdc_window_non_empty_calls": int(measurements["cdc_window_calls"]),
+        "cdc_window_empty_calls": 0,
+        "empty_window_ratio": 0.0,
         "cdc_changes_calls": int(measurements["cdc_changes_calls"]),
         "cdc_commit_calls": int(measurements["cdc_commit_calls"]),
     }
@@ -658,6 +700,7 @@ def main() -> int:
     parser.add_argument("--target-rows-per-snapshot", type=int)
     parser.add_argument("--consumers", type=int)
     parser.add_argument("--max-snapshots", type=int)
+    parser.add_argument("--empty-window-ratio", type=float)
     args = parser.parse_args()
 
     workload = load_workload(args.workload, args)
@@ -665,6 +708,8 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="ducklake_cdc_bench_") as tmp:
         tmpdir = Path(tmp)
         if args.runtime == "local-build":
+            if workload.empty_window_ratio > 0:
+                raise ValueError("empty_window_ratio workloads require --runtime official")
             paths = build_paths(args.build)
             require_artifacts(paths, args.build)
             binary = compile_harness(tmpdir, paths)

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -11,6 +11,14 @@
 // `NextExternalSchemaChangeSnapshot` (facts in `ducklake_metadata.cpp`)
 // and *decides* whether to truncate the visible window, then emits the
 // `CDC_SCHEMA_BOUNDARY` notice.
+//
+// Lease and commit state have two execution paths. DuckDB-backed state uses
+// single-statement `UPDATE ... RETURNING` for the hot path; attached catalog
+// backends that do not support RETURNING through DuckDB's scanner fall back to
+// the multi-statement legacy path. The legacy path is the reference behavior,
+// and the fast path must match its semantics. Keep `AcquireLeaseReturning` /
+// `AcquireLeaseLegacy` and the matching `cdc_commit` branches in sync when
+// changing lease ownership, expiration, or audit semantics.
 //===----------------------------------------------------------------------===//
 
 #include "consumer.hpp"
@@ -143,6 +151,11 @@ StateBackendKind DetectStateBackend(duckdb::Connection &conn, const std::string 
 }
 
 bool SupportsUpdateReturning(StateBackendKind backend) {
+	// DuckDB's sqlite_scanner and postgres_scanner currently reject
+	// `UPDATE ... RETURNING` for attached tables, even though both underlying
+	// engines support it natively. `test/catalog_matrix/catalog_matrix_smoke.py`
+	// has a small probe for this so the gate can be widened when scanners learn
+	// to round-trip RETURNING correctly.
 	return backend == StateBackendKind::DuckDB;
 }
 
@@ -782,26 +795,20 @@ std::vector<duckdb::Value> ResetConsumer(duckdb::ClientContext &context, const C
 
 	duckdb::Connection conn(*context.db);
 	const auto consumers = StateTable(conn, data.catalog_name, CONSUMERS_TABLE);
-	const auto subscriptions = StateTable(conn, data.catalog_name, CONSUMER_SUBSCRIPTIONS_TABLE);
-	try {
-		auto row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
-		int64_t resolved_snapshot = ResolveResetSnapshot(conn, data.catalog_name, data.to_snapshot);
-		int64_t schema_version = ResolveSchemaVersion(conn, data.catalog_name, resolved_snapshot);
-		const auto details = "{\"from_snapshot\":" + std::to_string(row.last_committed_snapshot) +
-		                     ",\"to_snapshot\":" + std::to_string(resolved_snapshot) + ",\"reset_kind\":\"" +
-		                     JsonEscape(ResetKind(data.to_snapshot)) + "\"}";
-		ExecuteChecked(conn, "UPDATE " + consumers +
-		                         " SET last_committed_snapshot = " + std::to_string(resolved_snapshot) +
-		                         ", last_committed_schema_version = " + std::to_string(schema_version) +
-		                         ", owner_token = NULL, owner_acquired_at = NULL, owner_heartbeat_at = NULL, "
-		                         "updated_at = now() WHERE consumer_name = " +
-		                         QuoteLiteral(data.consumer_name));
-		InsertAuditRow(conn, data.catalog_name, "consumer_reset", data.consumer_name, row.consumer_id, details);
-		return {duckdb::Value(data.consumer_name), duckdb::Value::BIGINT(row.consumer_id),
-		        duckdb::Value::BIGINT(row.last_committed_snapshot), duckdb::Value::BIGINT(resolved_snapshot)};
-	} catch (...) {
-		throw;
-	}
+	auto row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
+	int64_t resolved_snapshot = ResolveResetSnapshot(conn, data.catalog_name, data.to_snapshot);
+	int64_t schema_version = ResolveSchemaVersion(conn, data.catalog_name, resolved_snapshot);
+	const auto details = "{\"from_snapshot\":" + std::to_string(row.last_committed_snapshot) +
+	                     ",\"to_snapshot\":" + std::to_string(resolved_snapshot) + ",\"reset_kind\":\"" +
+	                     JsonEscape(ResetKind(data.to_snapshot)) + "\"}";
+	ExecuteChecked(conn, "UPDATE " + consumers + " SET last_committed_snapshot = " + std::to_string(resolved_snapshot) +
+	                         ", last_committed_schema_version = " + std::to_string(schema_version) +
+	                         ", owner_token = NULL, owner_acquired_at = NULL, owner_heartbeat_at = NULL, "
+	                         "updated_at = now() WHERE consumer_name = " +
+	                         QuoteLiteral(data.consumer_name));
+	InsertAuditRow(conn, data.catalog_name, "consumer_reset", data.consumer_name, row.consumer_id, details);
+	return {duckdb::Value(data.consumer_name), duckdb::Value::BIGINT(row.consumer_id),
+	        duckdb::Value::BIGINT(row.last_committed_snapshot), duckdb::Value::BIGINT(resolved_snapshot)};
 }
 
 duckdb::unique_ptr<duckdb::GlobalTableFunctionState> ConsumerResetInit(duckdb::ClientContext &context,
@@ -855,20 +862,15 @@ std::vector<duckdb::Value> DropConsumer(duckdb::ClientContext &context, const Co
 	duckdb::Connection conn(*context.db);
 	const auto consumers = StateTable(conn, data.catalog_name, CONSUMERS_TABLE);
 	const auto subscriptions = StateTable(conn, data.catalog_name, CONSUMER_SUBSCRIPTIONS_TABLE);
-	try {
-		auto row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
-		const auto details = "{\"last_committed_snapshot\":" + std::to_string(row.last_committed_snapshot) +
-		                     ",\"last_committed_schema_version\":" + std::to_string(row.last_committed_schema_version) +
-		                     "}";
-		InsertAuditRow(conn, data.catalog_name, "consumer_drop", data.consumer_name, row.consumer_id, details);
-		ExecuteChecked(conn,
-		               "DELETE FROM " + subscriptions + " WHERE consumer_id = " + std::to_string(row.consumer_id));
-		ExecuteChecked(conn, "DELETE FROM " + consumers + " WHERE consumer_name = " + QuoteLiteral(data.consumer_name));
-		return {duckdb::Value(data.consumer_name), duckdb::Value::BIGINT(row.consumer_id),
-		        duckdb::Value::BIGINT(row.last_committed_snapshot)};
-	} catch (...) {
-		throw;
-	}
+	auto row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
+	const auto details = "{\"last_committed_snapshot\":" + std::to_string(row.last_committed_snapshot) +
+	                     ",\"last_committed_schema_version\":" + std::to_string(row.last_committed_schema_version) +
+	                     "}";
+	InsertAuditRow(conn, data.catalog_name, "consumer_drop", data.consumer_name, row.consumer_id, details);
+	ExecuteChecked(conn, "DELETE FROM " + subscriptions + " WHERE consumer_id = " + std::to_string(row.consumer_id));
+	ExecuteChecked(conn, "DELETE FROM " + consumers + " WHERE consumer_name = " + QuoteLiteral(data.consumer_name));
+	return {duckdb::Value(data.consumer_name), duckdb::Value::BIGINT(row.consumer_id),
+	        duckdb::Value::BIGINT(row.last_committed_snapshot)};
 }
 
 duckdb::unique_ptr<duckdb::GlobalTableFunctionState> ConsumerDropInit(duckdb::ClientContext &context,
@@ -921,22 +923,18 @@ std::vector<duckdb::Value> ForceReleaseConsumer(duckdb::ClientContext &context, 
 
 	duckdb::Connection conn(*context.db);
 	const auto consumers = StateTable(conn, data.catalog_name, CONSUMERS_TABLE);
-	try {
-		auto row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
-		const auto details = "{\"previous_token\":" + JsonValue(row.owner_token) +
-		                     ",\"previous_acquired_at\":" + JsonValue(row.owner_acquired_at) +
-		                     ",\"previous_heartbeat_at\":" + JsonValue(row.owner_heartbeat_at) + "}";
-		ExecuteChecked(conn, "UPDATE " + consumers +
-		                         " SET owner_token = NULL, owner_acquired_at = NULL, owner_heartbeat_at = NULL, "
-		                         "updated_at = now() WHERE consumer_name = " +
-		                         QuoteLiteral(data.consumer_name));
-		InsertAuditRow(conn, data.catalog_name, "consumer_force_release", data.consumer_name, row.consumer_id, details);
-		duckdb::Value previous_token =
-		    row.owner_token.IsNull() ? duckdb::Value() : duckdb::Value(row.owner_token.ToString());
-		return {duckdb::Value(data.consumer_name), duckdb::Value::BIGINT(row.consumer_id), previous_token};
-	} catch (...) {
-		throw;
-	}
+	auto row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
+	const auto details = "{\"previous_token\":" + JsonValue(row.owner_token) +
+	                     ",\"previous_acquired_at\":" + JsonValue(row.owner_acquired_at) +
+	                     ",\"previous_heartbeat_at\":" + JsonValue(row.owner_heartbeat_at) + "}";
+	ExecuteChecked(conn, "UPDATE " + consumers +
+	                         " SET owner_token = NULL, owner_acquired_at = NULL, owner_heartbeat_at = NULL, "
+	                         "updated_at = now() WHERE consumer_name = " +
+	                         QuoteLiteral(data.consumer_name));
+	InsertAuditRow(conn, data.catalog_name, "consumer_force_release", data.consumer_name, row.consumer_id, details);
+	duckdb::Value previous_token =
+	    row.owner_token.IsNull() ? duckdb::Value() : duckdb::Value(row.owner_token.ToString());
+	return {duckdb::Value(data.consumer_name), duckdb::Value::BIGINT(row.consumer_id), previous_token};
 }
 
 duckdb::unique_ptr<duckdb::GlobalTableFunctionState> ConsumerForceReleaseInit(duckdb::ClientContext &context,
@@ -1126,6 +1124,10 @@ WindowResolution ResolveWindowFast(duckdb::Connection &conn, const std::string &
 	const auto changes_table = MetadataTable(catalog_name, "ducklake_snapshot_changes");
 	const auto last_snapshot_sql = std::to_string(last_snapshot);
 	const auto max_snapshots_sql = std::to_string(max_snapshots);
+	const auto schema_change_filter = "(sc.changes_made LIKE 'created_%' OR sc.changes_made LIKE '%,created_%' OR "
+	                                  "sc.changes_made LIKE 'altered_%' OR sc.changes_made LIKE '%,altered_%' OR "
+	                                  "sc.changes_made LIKE 'dropped_%' OR sc.changes_made LIKE '%,dropped_%' OR "
+	                                  "sc.changes_made LIKE 'renamed_%' OR sc.changes_made LIKE '%,renamed_%')";
 	auto result =
 	    conn.Query("WITH snapshot_bounds AS ("
 	               "SELECT max(snapshot_id) AS current_snapshot, min(snapshot_id) AS oldest_snapshot, "
@@ -1151,8 +1153,9 @@ WindowResolution ResolveWindowFast(duckdb::Connection &conn, const std::string &
 	               snapshot_table + " last_s ON last_s.snapshot_id = " + last_snapshot_sql + " LEFT JOIN " +
 	               snapshot_table + " start_s ON start_s.snapshot_id = c.start_snapshot LEFT JOIN " + snapshot_table +
 	               " end_s ON end_s.snapshot_id = c.end_snapshot LEFT JOIN " + changes_table +
-	               " sc ON sc.snapshot_id >= c.start_snapshot AND sc.snapshot_id <= c.current_snapshot LEFT JOIN " +
-	               snapshot_table + " change_s ON change_s.snapshot_id = sc.snapshot_id ORDER BY sc.snapshot_id ASC");
+	               " sc ON sc.snapshot_id >= c.start_snapshot AND sc.snapshot_id <= c.current_snapshot AND " +
+	               schema_change_filter + " LEFT JOIN " + snapshot_table +
+	               " change_s ON change_s.snapshot_id = sc.snapshot_id ORDER BY sc.snapshot_id ASC");
 	ThrowIfQueryFailed(result);
 	if (!result || result->RowCount() == 0 || result->GetValue(0, 0).IsNull()) {
 		throw duckdb::InvalidInputException("Unable to resolve current snapshot");
@@ -1266,46 +1269,40 @@ std::vector<duckdb::Value> CommitWindow(duckdb::ClientContext &context, const Cd
 	const auto backend = DetectStateBackend(conn, data.catalog_name);
 	const auto consumers = StateTable(conn, data.catalog_name, CONSUMERS_TABLE);
 	const auto cached_token = CachedToken(context, data.catalog_name, data.consumer_name);
-	try {
-		const auto snapshot_table = MetadataTable(data.catalog_name, "ducklake_snapshot");
-		if (SupportsUpdateReturning(backend)) {
-			auto fast_commit = conn.Query(
-			    "UPDATE " + consumers + " SET last_committed_snapshot = " + std::to_string(data.snapshot_id) +
-			    ", last_committed_schema_version = (SELECT schema_version FROM " + snapshot_table +
-			    " WHERE snapshot_id = " + std::to_string(data.snapshot_id) +
-			    " LIMIT 1), owner_heartbeat_at = now(), updated_at = now() WHERE consumer_name = " +
-			    QuoteLiteral(data.consumer_name) + " AND owner_token = " + TokenSqlOrNull(cached_token) +
-			    " AND last_committed_snapshot <= " + std::to_string(data.snapshot_id) + " AND EXISTS (SELECT 1 FROM " +
-			    snapshot_table + " WHERE snapshot_id = " + std::to_string(data.snapshot_id) +
-			    ") RETURNING consumer_name, last_committed_snapshot, last_committed_schema_version");
-			ThrowIfQueryFailed(fast_commit);
-			if (fast_commit && fast_commit->RowCount() > 0) {
-				return {fast_commit->GetValue(0, 0), fast_commit->GetValue(1, 0), fast_commit->GetValue(2, 0)};
-			}
+	const auto snapshot_table = MetadataTable(data.catalog_name, "ducklake_snapshot");
+	if (SupportsUpdateReturning(backend)) {
+		auto fast_commit = conn.Query(
+		    "UPDATE " + consumers + " SET last_committed_snapshot = " + std::to_string(data.snapshot_id) +
+		    ", last_committed_schema_version = (SELECT schema_version FROM " + snapshot_table +
+		    " WHERE snapshot_id = " + std::to_string(data.snapshot_id) +
+		    " LIMIT 1), owner_heartbeat_at = now(), updated_at = now() WHERE consumer_name = " +
+		    QuoteLiteral(data.consumer_name) + " AND owner_token = " + TokenSqlOrNull(cached_token) +
+		    " AND last_committed_snapshot <= " + std::to_string(data.snapshot_id) + " AND EXISTS (SELECT 1 FROM " +
+		    snapshot_table + " WHERE snapshot_id = " + std::to_string(data.snapshot_id) +
+		    ") RETURNING consumer_name, last_committed_snapshot, last_committed_schema_version");
+		ThrowIfQueryFailed(fast_commit);
+		if (fast_commit && fast_commit->RowCount() > 0) {
+			return {fast_commit->GetValue(0, 0), fast_commit->GetValue(1, 0), fast_commit->GetValue(2, 0)};
 		}
-
-		auto row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
-		if (cached_token.empty() || row.owner_token.IsNull() || row.owner_token.ToString() != cached_token) {
-			ThrowBusy(conn, data.catalog_name, data.consumer_name);
-		}
-		ValidateCommitSnapshot(conn, data.catalog_name, data.consumer_name, row.last_committed_snapshot,
-		                       data.snapshot_id);
-		const auto schema_version = ResolveSchemaVersion(conn, data.catalog_name, data.snapshot_id);
-		ExecuteChecked(conn,
-		               "UPDATE " + consumers + " SET last_committed_snapshot = " + std::to_string(data.snapshot_id) +
-		                   ", last_committed_schema_version = " + std::to_string(schema_version) +
-		                   ", owner_heartbeat_at = now(), updated_at = now() WHERE consumer_name = " +
-		                   QuoteLiteral(data.consumer_name) + " AND owner_token = " + TokenSqlOrNull(cached_token));
-		row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
-		if (row.last_committed_snapshot != data.snapshot_id || row.owner_token.IsNull() ||
-		    row.owner_token.ToString() != cached_token) {
-			ThrowBusy(conn, data.catalog_name, data.consumer_name);
-		}
-		return {duckdb::Value(data.consumer_name), duckdb::Value::BIGINT(data.snapshot_id),
-		        duckdb::Value::BIGINT(schema_version)};
-	} catch (...) {
-		throw;
 	}
+
+	auto row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
+	if (cached_token.empty() || row.owner_token.IsNull() || row.owner_token.ToString() != cached_token) {
+		ThrowBusy(conn, data.catalog_name, data.consumer_name);
+	}
+	ValidateCommitSnapshot(conn, data.catalog_name, data.consumer_name, row.last_committed_snapshot, data.snapshot_id);
+	const auto schema_version = ResolveSchemaVersion(conn, data.catalog_name, data.snapshot_id);
+	ExecuteChecked(conn, "UPDATE " + consumers + " SET last_committed_snapshot = " + std::to_string(data.snapshot_id) +
+	                         ", last_committed_schema_version = " + std::to_string(schema_version) +
+	                         ", owner_heartbeat_at = now(), updated_at = now() WHERE consumer_name = " +
+	                         QuoteLiteral(data.consumer_name) + " AND owner_token = " + TokenSqlOrNull(cached_token));
+	row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
+	if (row.last_committed_snapshot != data.snapshot_id || row.owner_token.IsNull() ||
+	    row.owner_token.ToString() != cached_token) {
+		ThrowBusy(conn, data.catalog_name, data.consumer_name);
+	}
+	return {duckdb::Value(data.consumer_name), duckdb::Value::BIGINT(data.snapshot_id),
+	        duckdb::Value::BIGINT(schema_version)};
 }
 
 duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcCommitInit(duckdb::ClientContext &context,
@@ -1358,22 +1355,18 @@ std::vector<duckdb::Value> HeartbeatConsumer(duckdb::ClientContext &context, con
 	duckdb::Connection conn(*context.db);
 	const auto consumers = StateTable(conn, data.catalog_name, CONSUMERS_TABLE);
 	const auto cached_token = CachedToken(context, data.catalog_name, data.consumer_name);
-	try {
-		auto row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
-		if (cached_token.empty() || row.owner_token.IsNull() || row.owner_token.ToString() != cached_token) {
-			ThrowBusy(conn, data.catalog_name, data.consumer_name);
-		}
-		ExecuteChecked(
-		    conn, "UPDATE " + consumers + " SET owner_heartbeat_at = now(), updated_at = now() WHERE consumer_name = " +
-		              QuoteLiteral(data.consumer_name) + " AND owner_token = " + TokenSqlOrNull(cached_token));
-		row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
-		if (row.owner_token.IsNull() || row.owner_token.ToString() != cached_token) {
-			ThrowBusy(conn, data.catalog_name, data.consumer_name);
-		}
-		return {duckdb::Value::BOOLEAN(true)};
-	} catch (...) {
-		throw;
+	auto row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
+	if (cached_token.empty() || row.owner_token.IsNull() || row.owner_token.ToString() != cached_token) {
+		ThrowBusy(conn, data.catalog_name, data.consumer_name);
 	}
+	ExecuteChecked(conn, "UPDATE " + consumers +
+	                         " SET owner_heartbeat_at = now(), updated_at = now() WHERE consumer_name = " +
+	                         QuoteLiteral(data.consumer_name) + " AND owner_token = " + TokenSqlOrNull(cached_token));
+	row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
+	if (row.owner_token.IsNull() || row.owner_token.ToString() != cached_token) {
+		ThrowBusy(conn, data.catalog_name, data.consumer_name);
+	}
+	return {duckdb::Value::BOOLEAN(true)};
 }
 
 duckdb::unique_ptr<duckdb::GlobalTableFunctionState> ConsumerHeartbeatInit(duckdb::ClientContext &context,
@@ -1825,82 +1818,78 @@ std::vector<duckdb::Value> ReadWindow(duckdb::ClientContext &context, const CdcW
 	duckdb::Connection conn(*context.db);
 	const auto backend = DetectStateBackend(conn, data.catalog_name);
 	const auto cached_token = CachedToken(context, data.catalog_name, data.consumer_name);
-	try {
-		auto row = AcquireLease(conn, data.catalog_name, data.consumer_name, cached_token, backend);
-		const auto last_snapshot = row.last_committed_snapshot;
-		const auto stop_at_schema_change = row.stop_at_schema_change;
-		const auto owner_token = row.owner_token.ToString();
-		CacheToken(context, data.catalog_name, data.consumer_name, owner_token);
+	auto row = AcquireLease(conn, data.catalog_name, data.consumer_name, cached_token, backend);
+	const auto last_snapshot = row.last_committed_snapshot;
+	const auto stop_at_schema_change = row.stop_at_schema_change;
+	const auto owner_token = row.owner_token.ToString();
+	CacheToken(context, data.catalog_name, data.consumer_name, owner_token);
 
-		const auto resolved = ResolveWindowFast(conn, data.catalog_name, last_snapshot, data.max_snapshots);
-		if (!resolved.last_snapshot_exists) {
-			const auto oldest_snapshot = RequiredInt64(resolved.oldest_snapshot, "oldest snapshot");
-			throw duckdb::InvalidInputException(
-			    "CDC_GAP: consumer '%s' is at snapshot %lld, but the oldest available snapshot is %lld. To recover "
-			    "and skip the gap: CALL cdc_consumer_reset('%s', '%s', to_snapshot => 'oldest_available'); To "
-			    "preserve all events, run consumers more frequently than your expire_older_than setting.",
-			    data.consumer_name, static_cast<long long>(last_snapshot), static_cast<long long>(oldest_snapshot),
-			    data.catalog_name, data.consumer_name);
-		}
-		const auto current_snapshot = resolved.current_snapshot;
-		const auto first_snapshot = resolved.first_snapshot;
-		const auto start_snapshot = resolved.start_snapshot;
-		int64_t end_snapshot = resolved.end_snapshot;
-		bool schema_changes_pending = false;
-		int64_t boundary_next_snapshot = -1;
-		duckdb::Value boundary_next_schema_version;
-		auto schema_version = last_snapshot <= current_snapshot
-		                          ? RequiredInt64(resolved.last_schema_version, "schema_version")
-		                          : row.last_committed_schema_version;
-		if (first_snapshot != -1 && start_snapshot <= current_snapshot) {
-			schema_version = RequiredInt64(resolved.start_schema_version, "schema_version");
-			// `start_snapshot` itself can be a schema-change snapshot
-			// (e.g. consumer just committed past the previous boundary
-			// and is now reading the ALTER). The window includes it
-			// regardless of `stop_at_schema_change`; we only need to
-			// surface `schema_changes_pending = true` so callers know
-			// the window straddles a schema version transition.
-			if (resolved.start_is_schema_change) {
-				schema_changes_pending = true;
-			}
-			const auto next_schema_change = resolved.next_schema_change;
-			if (next_schema_change != -1 && next_schema_change <= end_snapshot) {
-				schema_changes_pending = true;
-				if (stop_at_schema_change) {
-					end_snapshot = next_schema_change - 1;
-				}
-				boundary_next_snapshot = next_schema_change;
-				boundary_next_schema_version = resolved.next_schema_change_schema_version;
-			}
-		}
-		const bool has_changes = end_snapshot >= start_snapshot;
-		// docs/errors.md spells the notice as "window ends at snapshot N
-		// (schema_version X); the next snapshot is at schema_version Y".
-		// `schema_version` is the schema at `start_snapshot` (kept that
-		// way for the row payload contract); compute the schema at the
-		// actual `end_snapshot` for the notice so X<Y reads correctly
-		// even when the window collapsed to a single snapshot at the
-		// boundary.
-		int64_t end_schema_version_for_notice = -1;
-		if (schema_changes_pending && boundary_next_snapshot != -1) {
-			end_schema_version_for_notice = RequiredInt64(
-			    has_changes ? resolved.end_schema_version : resolved.last_schema_version, "schema_version");
-		}
-		// Emit the CDC_SCHEMA_BOUNDARY notice after COMMIT so a downstream
-		// caller's logging side-effect can never roll back the metadata
-		// write the lease UPDATE just landed.
-		if (schema_changes_pending && boundary_next_snapshot != -1 &&
-		    end_schema_version_for_notice != RequiredInt64(boundary_next_schema_version, "schema_version")) {
-			EmitSchemaBoundaryNotice(data.consumer_name, has_changes ? end_snapshot : last_snapshot,
-			                         end_schema_version_for_notice, boundary_next_snapshot,
-			                         RequiredInt64(boundary_next_schema_version, "schema_version"));
-		}
-		return {duckdb::Value::BIGINT(start_snapshot), duckdb::Value::BIGINT(end_snapshot),
-		        duckdb::Value::BOOLEAN(has_changes), duckdb::Value::BIGINT(schema_version),
-		        duckdb::Value::BOOLEAN(schema_changes_pending)};
-	} catch (...) {
-		throw;
+	const auto resolved = ResolveWindowFast(conn, data.catalog_name, last_snapshot, data.max_snapshots);
+	if (!resolved.last_snapshot_exists) {
+		const auto oldest_snapshot = RequiredInt64(resolved.oldest_snapshot, "oldest snapshot");
+		throw duckdb::InvalidInputException(
+		    "CDC_GAP: consumer '%s' is at snapshot %lld, but the oldest available snapshot is %lld. To recover "
+		    "and skip the gap: CALL cdc_consumer_reset('%s', '%s', to_snapshot => 'oldest_available'); To "
+		    "preserve all events, run consumers more frequently than your expire_older_than setting.",
+		    data.consumer_name, static_cast<long long>(last_snapshot), static_cast<long long>(oldest_snapshot),
+		    data.catalog_name, data.consumer_name);
 	}
+	const auto current_snapshot = resolved.current_snapshot;
+	const auto first_snapshot = resolved.first_snapshot;
+	const auto start_snapshot = resolved.start_snapshot;
+	int64_t end_snapshot = resolved.end_snapshot;
+	bool schema_changes_pending = false;
+	int64_t boundary_next_snapshot = -1;
+	duckdb::Value boundary_next_schema_version;
+	auto schema_version = last_snapshot <= current_snapshot
+	                          ? RequiredInt64(resolved.last_schema_version, "schema_version")
+	                          : row.last_committed_schema_version;
+	if (first_snapshot != -1 && start_snapshot <= current_snapshot) {
+		schema_version = RequiredInt64(resolved.start_schema_version, "schema_version");
+		// `start_snapshot` itself can be a schema-change snapshot
+		// (e.g. consumer just committed past the previous boundary
+		// and is now reading the ALTER). The window includes it
+		// regardless of `stop_at_schema_change`; we only need to
+		// surface `schema_changes_pending = true` so callers know
+		// the window straddles a schema version transition.
+		if (resolved.start_is_schema_change) {
+			schema_changes_pending = true;
+		}
+		const auto next_schema_change = resolved.next_schema_change;
+		if (next_schema_change != -1 && next_schema_change <= end_snapshot) {
+			schema_changes_pending = true;
+			if (stop_at_schema_change) {
+				end_snapshot = next_schema_change - 1;
+			}
+			boundary_next_snapshot = next_schema_change;
+			boundary_next_schema_version = resolved.next_schema_change_schema_version;
+		}
+	}
+	const bool has_changes = end_snapshot >= start_snapshot;
+	// docs/errors.md spells the notice as "window ends at snapshot N
+	// (schema_version X); the next snapshot is at schema_version Y".
+	// `schema_version` is the schema at `start_snapshot` (kept that
+	// way for the row payload contract); compute the schema at the
+	// actual `end_snapshot` for the notice so X<Y reads correctly
+	// even when the window collapsed to a single snapshot at the
+	// boundary.
+	int64_t end_schema_version_for_notice = -1;
+	if (schema_changes_pending && boundary_next_snapshot != -1) {
+		end_schema_version_for_notice =
+		    RequiredInt64(has_changes ? resolved.end_schema_version : resolved.last_schema_version, "schema_version");
+	}
+	// Emit the CDC_SCHEMA_BOUNDARY notice after COMMIT so a downstream
+	// caller's logging side-effect can never roll back the metadata
+	// write the lease UPDATE just landed.
+	if (schema_changes_pending && boundary_next_snapshot != -1 &&
+	    end_schema_version_for_notice != RequiredInt64(boundary_next_schema_version, "schema_version")) {
+		EmitSchemaBoundaryNotice(data.consumer_name, has_changes ? end_snapshot : last_snapshot,
+		                         end_schema_version_for_notice, boundary_next_snapshot,
+		                         RequiredInt64(boundary_next_schema_version, "schema_version"));
+	}
+	return {duckdb::Value::BIGINT(start_snapshot), duckdb::Value::BIGINT(end_snapshot),
+	        duckdb::Value::BOOLEAN(has_changes), duckdb::Value::BIGINT(schema_version),
+	        duckdb::Value::BOOLEAN(schema_changes_pending)};
 }
 
 void RegisterConsumerFunctions(duckdb::ExtensionLoader &loader) {

--- a/test/catalog_matrix/catalog_matrix_smoke.py
+++ b/test/catalog_matrix/catalog_matrix_smoke.py
@@ -37,6 +37,15 @@ BUILD = os.environ.get("DUCKLAKE_CDC_BUILD", "release")
 DEFAULT_CDC_EXTENSION = REPO / "build" / BUILD / "extension" / "ducklake_cdc" / "ducklake_cdc.duckdb_extension"
 DEFAULT_BACKENDS = ("duckdb", "sqlite")
 ALL_BACKENDS = ("duckdb", "sqlite", "postgres")
+UPDATE_RETURNING_SUPPORTED = {
+    "duckdb": True,
+    # DuckDB's sqlite_scanner/postgres_scanner currently reject RETURNING for
+    # attached-table UPDATEs. Keep this probe near the backend matrix so the
+    # fast-path gate in consumer.cpp can be widened as soon as scanner support
+    # appears.
+    "sqlite": False,
+    "postgres": False,
+}
 DEFAULT_PG_DSN = "host=127.0.0.1 port=5434 user=ducklake password=ducklake dbname=ducklake"
 
 
@@ -154,6 +163,28 @@ def scalar(conn: duckdb.DuckDBPyConnection, sql: str) -> Any:
     return rows[0][0]
 
 
+def run_update_returning_probe(conn: duckdb.DuckDBPyConnection, backend: str) -> None:
+    require_ok(conn, "CREATE TABLE __ducklake_metadata_lake.returning_probe(id INTEGER, value INTEGER)")
+    require_ok(conn, "INSERT INTO __ducklake_metadata_lake.returning_probe VALUES (1, 10)")
+    sql = "UPDATE __ducklake_metadata_lake.returning_probe " "SET value = value + 1 WHERE id = 1 RETURNING id, value"
+    expected = UPDATE_RETURNING_SUPPORTED[backend]
+    if expected:
+        rows = require_rows(conn, sql)
+        if rows != [(1, 11)]:
+            raise RuntimeError(f"{backend}: UPDATE RETURNING returned unexpected rows: {rows!r}")
+        return
+    try:
+        rows = require_rows(conn, sql)
+    except RuntimeError as exc:
+        if "RETURNING clause not yet supported" in str(exc):
+            return
+        raise
+    raise RuntimeError(
+        f"{backend}: UPDATE RETURNING now works through the attached backend ({rows!r}); "
+        "widen SupportsUpdateReturning and update UPDATE_RETURNING_SUPPORTED"
+    )
+
+
 def run_demo_flow(conn: duckdb.DuckDBPyConnection, backend: str) -> None:
     consumer = f"matrix_demo_{backend}"
     require_ok(conn, "CREATE TABLE lake.orders(id INTEGER, amount INTEGER)")
@@ -250,6 +281,7 @@ def run_backend(name: str, cdc_extension: Path, pg_dsn: str) -> None:
         config = backend_config(name, Path(tmp), pg_dsn)
         print(f"[{name}] demo flow", flush=True)
         with connected(config, cdc_extension) as conn:
+            run_update_returning_probe(conn, name)
             run_demo_flow(conn, name)
     with tempfile.TemporaryDirectory(prefix=f"ducklake_cdc_{name}_lease_") as tmp:
         config = backend_config(name, Path(tmp), pg_dsn)


### PR DESCRIPTION
## Summary
- Document and test current `UPDATE ... RETURNING` scanner support: DuckDB stays on the fast path, while SQLite/Postgres remain gated until their scanners support attached-table RETURNING.
- Filter schema-change candidates in `ResolveWindowFast` so quiet windows do not fetch every change row only to discard DML-only snapshots in C++.
- Remove no-op catch/rethrow blocks and add an empty-window benchmark variant that records steady-state `cdc_window` latency.

## Test plan
- `python3 -m py_compile bench/runner.py test/catalog_matrix/catalog_matrix_smoke.py`
- `PATH="/tmp/clang-format-11-venv/bin:$PATH" make format-check`
- `make release`
- `uv run --locked python test/catalog_matrix/catalog_matrix_smoke.py --backends duckdb sqlite postgres`
- `make test_release_default`
- `uv run --locked python bench/runner.py --runtime official --cdc-extension build/release/extension/ducklake_cdc/ducklake_cdc.duckdb_extension --workload bench/empty-window.yaml --duration-seconds 4 --target-snapshots-per-second 1 --target-rows-per-snapshot 5 --output /tmp/ducklake-cdc-empty-window-smoke.json`

Note: the short benchmark smoke intentionally exceeded the catalog-QPS soft gate because the duration was reduced to 4 seconds for local verification.

Made with [Cursor](https://cursor.com)