### PR TITLE
Publish immutable artifacts and stable version metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,6 +308,21 @@ jobs:
             fi
           fi
 
+      - name: Validate version matches extension semantic version
+        if: ${{ inputs.community_pr_only != true && inputs.community_pr_only != 'true' }}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          cmake_version="$(sed -nE 's/^project\([^)]* VERSION ([0-9]+\.[0-9]+\.[0-9]+)\).*$/\1/p' CMakeLists.txt)"
+          if [[ -z "$cmake_version" ]]; then
+            echo "::error::Could not read the project VERSION from CMakeLists.txt."
+            exit 1
+          fi
+          if [[ "v$cmake_version" != "$VERSION" ]]; then
+            echo "::error::Release input $VERSION does not match CMake project version v$cmake_version."
+            exit 1
+          fi
+
       - name: Verify tag does not already exist
         if: ${{ inputs.community_pr_only != true && inputs.community_pr_only != 'true' }}
         env:
@@ -476,6 +491,50 @@ jobs:
             echo "Will retry the \`duckdb/community-extensions\` PR for existing tag \`$VERSION\` at \`$RELEASE_SHA\`."
             echo "No tags, branches, or GitHub Releases will be created in this repository."
           } >> "$GITHUB_STEP_SUMMARY"
+
+  release-assets:
+    name: Publish immutable release binaries
+    needs:
+      - resolve-duckdb-version
+      - release
+    if: ${{ inputs.dry_run != true && inputs.dry_run != 'true' && inputs.community_pr_only != true && inputs.community_pr_only != 'true' && needs.release.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download tested distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ducklake_cdc-${{ needs.resolve-duckdb-version.outputs.duckdb_version }}-extension-*
+          path: release-artifacts
+
+      - name: Give artifacts immutable release names and checksums
+        env:
+          VERSION: ${{ inputs.version }}
+          DUCKDB_VERSION: ${{ needs.resolve-duckdb-version.outputs.duckdb_version }}
+        run: |
+          set -euo pipefail
+          mkdir release-upload
+          for artifact_dir in release-artifacts/*; do
+            artifact_name="${artifact_dir##*/}"
+            platform="${artifact_name##*-extension-}"
+            source_file="$(find "$artifact_dir" -type f -name 'ducklake_cdc.duckdb_extension*' -print -quit)"
+            if [[ -z "$source_file" ]]; then
+              echo "::error::No extension binary found in $artifact_dir."
+              exit 1
+            fi
+            suffix=".duckdb_extension"
+            if [[ "$source_file" == *.wasm ]]; then
+              suffix=".duckdb_extension.wasm"
+            fi
+            cp "$source_file" "release-upload/ducklake_cdc-${VERSION}-duckdb-${DUCKDB_VERSION}-${platform}${suffix}"
+          done
+          (cd release-upload && sha256sum ducklake_cdc-* > SHA256SUMS)
+          cat release-upload/SHA256SUMS
+
+      - name: Attach binaries and checksums to the GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: gh release upload "$VERSION" release-upload/* --repo "${{ github.repository }}" --clobber
 
   community-pr:
     name: Open community-extensions PR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(TARGET_NAME ducklake_cdc)
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
-project(${TARGET_NAME})
+project(${TARGET_NAME} VERSION 0.5.3)
 
 set(CMAKE_CXX_STANDARD "17" CACHE STRING "C++ standard to enforce")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -24,6 +24,9 @@ set(EXTENSION_SOURCES
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
+
+target_compile_definitions(${EXTENSION_NAME} PRIVATE DUCKLAKE_CDC_SEMVER="${PROJECT_VERSION}")
+target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE DUCKLAKE_CDC_SEMVER="${PROJECT_VERSION}")
 
 install(
   TARGETS ${EXTENSION_NAME}

--- a/docs/api.md
+++ b/docs/api.md
@@ -72,7 +72,22 @@ SELECT cdc_version();
 
 Returns the loaded extension version as a scalar `VARCHAR`.
 
+The value is the stable semantic release version, for example
+`ducklake_cdc 0.5.3`. Use `cdc_build_revision()` when an exact source/build
+identity is required.
+
 Use it in support tickets, CI logs, benchmark output, and migration checks.
+
+### `cdc_build_revision`
+
+```sql
+SELECT cdc_build_revision();
+```
+
+Returns the source revision stamped by the DuckDB extension build. Community
+builds normally report a short commit SHA; tagged local builds may report the
+tag. Pin production artifacts by release URL and SHA-256 digest rather than by
+this diagnostic value alone.
 
 ### `cdc_doctor`
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -117,7 +117,10 @@ Releases are manual and pragmatic:
 
 - day-to-day CI stays relatively small;
 - release CI builds the full DuckDB extension matrix;
-- community extension publishing is the main distribution path.
+- each GitHub release retains those exact matrix binaries and SHA-256 checksums
+  as the immutable pinning path;
+- community extension publishing is the signed latest-version distribution
+  path.
 
 The project should prefer clear docs, focused tests, and honest limitations
 over process-heavy release gates.

--- a/docs/development.md
+++ b/docs/development.md
@@ -163,10 +163,32 @@ feature_* -> main -> manual release
 - `release/0.x` branches are created only when an already-published line needs
   patch maintenance after `main` has moved on.
 
+### Immutable release binaries
+
+Every non-dry-run release attaches the exact full-matrix binaries to its GitHub
+Release. Asset names include the extension version, DuckDB version, and DuckDB
+platform, for example:
+
+```text
+ducklake_cdc-v0.5.3-duckdb-v1.5.4-linux_arm64.duckdb_extension
+```
+
+`SHA256SUMS` in the same release pins their contents. These maintainer release
+assets are unsigned: production images that use them must verify the digest,
+enable `allow_unsigned_extensions`, load the fixed path, and prevent the Python
+client from reinstalling the moving community build. The community repository
+remains the signed latest-version distribution channel.
+
+`cdc_version()` reports the stable extension semantic version.
+`cdc_build_revision()` reports the source revision stamped by the build. Treat
+the release URL plus SHA-256 digest—not either SQL string alone—as the immutable
+artifact identity.
+
 ## Where to start
 
 - `src/ducklake_cdc_extension.cpp` is the extension entry point. It registers
-  `cdc_version()` and calls into the per-domain `Register*Functions`.
+  `cdc_version()` / `cdc_build_revision()` and calls into the per-domain
+  `Register*Functions`.
 - `src/include/ducklake_metadata.hpp` is the shared facts layer (catalog
   table-name builders, snapshot lookups, JSON / quoting helpers, state-table
   DDL, lazy bootstrap). `src/ducklake_metadata.cpp` implements it.

--- a/src/compat_check.cpp
+++ b/src/compat_check.cpp
@@ -36,11 +36,10 @@ namespace {
 
 // Build-stamp literal that mirrors CdcVersionScalarFun() in
 // `src/ducklake_cdc_extension.cpp` so the user-facing notice and
-// `cdc_version()` agree on what extension build is reporting. Driven
-// entirely by `EXT_VERSION_DUCKLAKE_CDC` (tag or short SHA) per
-// docs/decisions/0013-versioning-and-release-automation.md.
-#ifdef EXT_VERSION_DUCKLAKE_CDC
-constexpr const char *EXTENSION_VERSION_LITERAL = "ducklake_cdc " EXT_VERSION_DUCKLAKE_CDC;
+// Keep compatibility diagnostics on the stable semantic version. Exact source
+// identity remains available separately through cdc_build_revision().
+#ifdef DUCKLAKE_CDC_SEMVER
+constexpr const char *EXTENSION_VERSION_LITERAL = "ducklake_cdc " DUCKLAKE_CDC_SEMVER;
 #else
 constexpr const char *EXTENSION_VERSION_LITERAL = "ducklake_cdc unknown";
 #endif

--- a/src/ducklake_cdc_extension.cpp
+++ b/src/ducklake_cdc_extension.cpp
@@ -13,18 +13,13 @@
 
 namespace duckdb {
 
-// Build-stamp string returned by `cdc_version()`. The version comes
-// from `EXT_VERSION_DUCKLAKE_CDC`, which the build system stamps from
-// `git tag --points-at HEAD` when releasing or from the short SHA on
-// untagged builds (see `extension-ci-tools/scripts/configure_helper.py`).
-// This matches the official DuckDB extension versioning convention:
-// untagged builds report an unstable identifier (short SHA), tagged
-// builds report the tag (pre-release while `v0.y.z`, stable from
-// `v1.0.0`). Per docs/decisions/0013-versioning-and-release-automation.md
-// there is no in-source version literal to bump on release.
+// Stable semantic version returned by `cdc_version()`. This is deliberately
+// separate from EXT_VERSION_DUCKLAKE_CDC: community-extensions checks out a
+// commit SHA without the release tag, so DuckDB's generated extension version
+// is a build revision rather than the descriptor's semantic version.
 inline void CdcVersionScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
-#ifdef EXT_VERSION_DUCKLAKE_CDC
-	const char *version_string = "ducklake_cdc " EXT_VERSION_DUCKLAKE_CDC;
+#ifdef DUCKLAKE_CDC_SEMVER
+	const char *version_string = "ducklake_cdc " DUCKLAKE_CDC_SEMVER;
 #else
 	const char *version_string = "ducklake_cdc unknown";
 #endif
@@ -33,9 +28,25 @@ inline void CdcVersionScalarFun(DataChunk &args, ExpressionState &state, Vector 
 	out[0] = StringVector::AddString(result, version_string);
 }
 
+// Source/build identity for exact artifact review and diagnostics. Unlike
+// cdc_version(), this is expected to vary between tagged and community builds.
+inline void CdcBuildRevisionScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+#ifdef EXT_VERSION_DUCKLAKE_CDC
+	const char *revision = EXT_VERSION_DUCKLAKE_CDC;
+#else
+	const char *revision = "unknown";
+#endif
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	auto out = ConstantVector::GetData<string_t>(result);
+	out[0] = StringVector::AddString(result, revision);
+}
+
 static void LoadInternal(ExtensionLoader &loader) {
 	auto cdc_version_function = ScalarFunction("cdc_version", {}, LogicalType::VARCHAR, CdcVersionScalarFun);
 	loader.RegisterFunction(cdc_version_function);
+	auto cdc_build_revision_function =
+	    ScalarFunction("cdc_build_revision", {}, LogicalType::VARCHAR, CdcBuildRevisionScalarFun);
+	loader.RegisterFunction(cdc_build_revision_function);
 	// Function registration is split across the four CDC domains:
 	//   - consumer: lifecycle (create/reset/drop/list/force_release/
 	//     heartbeat) + cursor primitives (window/commit).
@@ -67,8 +78,8 @@ std::string DucklakeCdcExtension::Name() {
 }
 
 std::string DucklakeCdcExtension::Version() const {
-#ifdef EXT_VERSION_DUCKLAKE_CDC
-	return EXT_VERSION_DUCKLAKE_CDC;
+#ifdef DUCKLAKE_CDC_SEMVER
+	return DUCKLAKE_CDC_SEMVER;
 #else
 	return "";
 #endif

--- a/test/version_and_load.test
+++ b/test/version_and_load.test
@@ -11,11 +11,13 @@ Catalog Error: Scalar Function with name cdc_version does not exist!
 # Require statement will ensure this test is run with this extension loaded.
 require ducklake_cdc
 
-# Confirm the extension's smoke-test function returns a build-stamp string.
-# The version segment after the prefix is the git tag at HEAD or a short
-# SHA on untagged builds (per docs/decisions/0013-versioning-and-release-automation.md);
-# we only assert on the prefix so this test stays valid across releases.
+# Confirm the public semantic version and separate build revision are present.
 query I
-SELECT cdc_version() ILIKE 'ducklake_cdc %';
+SELECT cdc_version();
+----
+ducklake_cdc 0.5.3
+
+query I
+SELECT length(cdc_build_revision()) > 0;
 ----
 true


### PR DESCRIPTION
## What changed

- Make `cdc_version()` and DuckDB extension metadata report the stable semantic version (`0.5.3`).
- Add `cdc_build_revision()` for the independently stamped source/build revision.
- Reject release dispatches whose requested version does not match the CMake project version.
- Download every successful distribution-matrix artifact, give it an immutable version/DuckDB/platform name, generate `SHA256SUMS`, and attach everything to the GitHub release.
- Document the signed moving community channel versus unsigned digest-pinned maintainer assets.

## Why

Community installation is intentionally a moving channel. Re-running `INSTALL ducklake_cdc FROM community` can install a newer reviewed build than an application image originally expected. In addition, community builds check out a commit SHA without its release tag, so the previous `cdc_version()` exposed a build revision even though the community descriptor carried a semantic version.

This separates semantic compatibility from exact artifact identity and gives production images an immutable release URL plus SHA-256 digest.

## Immediate release repair

The already-tested v0.5.2 matrix artifacts have also been attached manually to the existing release with `SHA256SUMS`, so consumers do not need to wait for v0.5.3 to pin DuckDB 1.5.4 binaries.

## Validation

- DuckDB 1.5.4 release build passed.
- Full SQLLogicTest suite passed: 305 assertions across 11 tests.
- `cdc_version()` returns `ducklake_cdc 0.5.3`.
- `cdc_build_revision()` returns the independently generated revision.
- `duckdb_extensions().extension_version` returns `0.5.3`.
- Release workflow YAML parsed successfully.
- clang-format 11.0.1 check passed.
