### PR TITLE
Add owner-safe lease release and harden bootstrap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(TARGET_NAME ducklake_cdc)
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
-project(${TARGET_NAME} VERSION 0.5.3)
+project(${TARGET_NAME} VERSION 0.5.4)
 
 set(CMAKE_CXX_STANDARD "17" CACHE STRING "C++ standard to enforce")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/docs/api.md
+++ b/docs/api.md
@@ -38,6 +38,7 @@ release.
   [`cdc_consumer_reset`](#cdc_consumer_reset),
   [`cdc_consumer_drop`](#cdc_consumer_drop),
   [`cdc_consumer_heartbeat`](#cdc_consumer_heartbeat),
+  [`cdc_consumer_release`](#cdc_consumer_release),
   [`cdc_consumer_force_release`](#cdc_consumer_force_release)
 - Cursor:
   [`cdc_window`](#cdc_window),
@@ -73,7 +74,7 @@ SELECT cdc_version();
 Returns the loaded extension version as a scalar `VARCHAR`.
 
 The value is the stable semantic release version, for example
-`ducklake_cdc 0.5.3`. Use `cdc_build_revision()` when an exact source/build
+`ducklake_cdc 0.5.4`. Use `cdc_build_revision()` when an exact source/build
 identity is required.
 
 Use it in support tickets, CI logs, benchmark output, and migration checks.
@@ -435,6 +436,30 @@ Returns:
 consumer_name VARCHAR
 consumer_id BIGINT
 previous_token UUID
+```
+
+### `cdc_consumer_release`
+
+```sql
+SELECT *
+FROM cdc_consumer_release(catalog, name);
+```
+
+Normal holder shutdown primitive. Clears the lease only when the calling
+DuckDB connection still owns it with the same cached owner token. If ownership
+has moved to another connection, the call raises `CDC_BUSY` and leaves the new
+owner untouched.
+
+Call this after the connection's in-flight CDC operation has returned and
+before closing the connection. Use `cdc_consumer_force_release` only as an
+operator action when the previous holder is known dead or wedged.
+
+Returns:
+
+```text
+consumer_name VARCHAR
+consumer_id BIGINT
+released_token UUID
 ```
 
 ---

--- a/docs/design.md
+++ b/docs/design.md
@@ -80,6 +80,9 @@ owner-token lease stored on the consumer row.
 
 The holder can call `cdc_window` repeatedly and get the same window until it
 commits. Another connection trying to read the same consumer gets `CDC_BUSY`.
+The holder releases during normal shutdown with `cdc_consumer_release`, which
+checks its connection-scoped owner token atomically. `cdc_consumer_force_release`
+is reserved for operators recovering a lease whose holder is known dead.
 
 Parallel reads are still possible inside one window: an orchestrator can hold
 the consumer lease, fan out ordinary `table_changes` reads, then commit once.

--- a/docs/development.md
+++ b/docs/development.md
@@ -170,7 +170,7 @@ Release. Asset names include the extension version, DuckDB version, and DuckDB
 platform, for example:
 
 ```text
-ducklake_cdc-v0.5.3-duckdb-v1.5.4-linux_arm64.duckdb_extension
+ducklake_cdc-v0.5.4-duckdb-v1.5.4-linux_arm64.duckdb_extension
 ```
 
 `SHA256SUMS` in the same release pins their contents. These maintainer release

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -28,7 +28,8 @@ your DuckLake retention window.
 Another connection owns the consumer lease, or the caller lost its lease before
 commit.
 
-Use `cdc_consumer_stats` to inspect the holder. Use
+Use `cdc_consumer_stats` to inspect the holder. Use `cdc_consumer_release` for
+normal holder shutdown. Use
 `cdc_consumer_force_release` only when you know the holder is dead.
 
 ### `CDC_MAX_SNAPSHOTS_EXCEEDED`

--- a/docs/hazard-log.md
+++ b/docs/hazard-log.md
@@ -448,9 +448,26 @@ go; this file says what can hurt users or maintainers on the way there.
   `DMLConsumer` lease connection both follow this pattern). Both
   workarounds are example-side; closing the hazard at source still
   needs the upstream lock-ordering fix the original notes describe.
-- Next action: If we see this hit by a real user outside the
-  regression-test pattern, capture an MSVC debug-build stack trace at
-  the `std::system_error(resource_deadlock_would_occur)` throw site to
-  identify the specific shared mutex, then either serialize the
-  outer-to-inner transition in our code or file an upstream issue on
-  the offending lock's ordering contract.
+- Atlas production-shaped reproduction (July 2026): Atlas surfaced bare
+  `_duckdb.Error: Resource deadlock avoided` from
+  `cdc_dml_consumer_create` while opening its crawl planner against a populated
+  Postgres DuckLake catalog. The standalone
+  `e2e/smoke/h022_atlas_setup_smoke.py` reproducer creates catalog history and
+  performs concurrent planner setup. Before the local mitigation, Atlas's
+  shared catalogue-connection shape failed 1/100 attempts while the client's
+  dedicated derived-connection shape passed 100/100.
+- Handling (populated catalogs): bootstrap now probes the state table and
+  returns immediately when it exists, rather than rerunning three `CREATE TABLE
+  IF NOT EXISTS` statements plus Postgres trigger DDL on every `cdc_*` setup.
+  Genuine first bootstrap is serialized and rechecked within one process.
+  This removes the avoidable repeated-DDL lock handoff; callers must still use
+  a dedicated derived connection for CDC. After this mitigation both shapes
+  passed 100/100 populated-catalog attempts in the standalone stress test.
+- Remaining upstream boundary: first bootstrap from multiple processes, and
+  the fundamental outer `ClientContext` to inner `Connection` catalog-lock
+  ordering, cannot be made atomic solely by this extension. Escalate the
+  standalone reproducer and a debug stack at the `std::system_error` throw site
+  to DuckDB/DuckLake. The reproducer's `--first-bootstrap-race` mode isolates
+  this boundary: the shared-connection shape surfaced `thread::join failed:
+  Invalid argument` in 1/16 attempts while the derived-connection control
+  passed 16/16.

--- a/docs/hazard-log.md
+++ b/docs/hazard-log.md
@@ -463,6 +463,10 @@ go; this file says what can hurt users or maintainers on the way there.
   This removes the avoidable repeated-DDL lock handoff; callers must still use
   a dedicated derived connection for CDC. After this mitigation both shapes
   passed 100/100 populated-catalog attempts in the standalone stress test.
+- Handling (catchable surfaces): consumer creation and the schema-diff MAP
+  scan retry the three known H-022 spellings up to five times with a short
+  bounded backoff. This keeps transient lock/thread teardown errors from
+  escaping normal SQL callers; it cannot recover an uncaught runtime abort.
 - Remaining upstream boundary: first bootstrap from multiple processes, and
   the fundamental outer `ClientContext` to inner `Connection` catalog-lock
   ordering, cannot be made atomic solely by this extension. Escalate the

--- a/e2e/smoke/h022_atlas_setup_smoke.py
+++ b/e2e/smoke/h022_atlas_setup_smoke.py
@@ -1,0 +1,176 @@
+"""Reproduce Atlas-shaped CDC setup on a populated Postgres DuckLake catalog.
+
+Atlas historically created ``CDCClient`` on its general catalogue connection,
+read the latest snapshot, then passed that client into ``DMLConsumer``.  That
+keeps consumer setup on the same outer connection that just touched DuckLake
+metadata and can surface H-022's outer/inner connection lock handoff.
+
+This smoke runs that shared-connection shape and the high-level client's normal
+derived-connection shape side by side.  It requires the e2e Postgres services:
+
+    docker compose -f e2e/docker-compose.yml up -d --wait postgres pgbouncer
+    uv run --project e2e python e2e/smoke/h022_atlas_setup_smoke.py --attempts 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+SMOKE_DIR = Path(__file__).resolve().parent
+E2E_DIR = SMOKE_DIR.parent
+if str(E2E_DIR) not in sys.path:
+    sys.path.insert(0, str(E2E_DIR))
+
+from ducklake_cdc_client import CDCClient, DMLConsumer  # noqa: E402
+
+from _lib.config import load_cdc_extension, open_lake, reset_lake  # noqa: E402
+
+EXAMPLE = "h022_atlas_setup"
+TABLE = "main.crawls"
+CONSUMER = "atlas-crawl-materialization-planner"
+
+
+def _prepare(*, history: int, bootstrap_cdc: bool) -> None:
+    reset_lake(example=EXAMPLE, catalog="postgres", storage="disk")
+    with open_lake(example=EXAMPLE, catalog="postgres", storage="disk") as lake:
+        load_cdc_extension(lake)
+        lake.connection.execute(
+            "CREATE TABLE lake.main.crawls(crawl_id UUID, captured_at TIMESTAMPTZ)"
+        )
+        for index in range(history):
+            lake.connection.execute(
+                "INSERT INTO lake.main.crawls VALUES (uuid(), now())"
+            )
+            if index % 5 == 0:
+                lake.connection.execute(
+                    f"CREATE TABLE lake.main.history_{index}(id INTEGER)"
+                )
+        if bootstrap_cdc:
+            # Commit a single-threaded first bootstrap. The default stress
+            # phase is about Atlas's setup against an already-populated CDC
+            # catalog, not racing initial schema creation. Pass
+            # --first-bootstrap-race to isolate the remaining core handoff.
+            client = CDCClient(lake, install_extension=False)
+            client.cdc_dml_consumer_create(
+                "h022-bootstrap",
+                table_name=TABLE,
+                start_at="now",
+            )
+            client.cdc_consumer_drop("h022-bootstrap")
+
+
+def _attempt(*, shared_connection: bool, attempt: int) -> None:
+    with open_lake(example=EXAMPLE, catalog="postgres", storage="disk") as lake:
+        load_cdc_extension(lake)
+        # Atlas obtains start_at on the catalogue connection before setup.
+        start_at = lake.snapshots.latest()
+        if start_at is None:
+            raise RuntimeError("DuckLake has no snapshot")
+
+        consumer_name = f"{CONSUMER}-{attempt}"
+        if shared_connection:
+            client = CDCClient(lake, install_extension=False)
+            consumer = DMLConsumer(
+                lake,
+                consumer_name,
+                table=TABLE,
+                mode="changes",
+                start_at=start_at,
+                on_exists="use",
+                client=client,
+            ).open()
+        else:
+            # No explicit client: DMLConsumer derives and prewarms a dedicated
+            # cursor, separating CDC table functions from catalogue reads.
+            consumer = DMLConsumer(
+                lake,
+                consumer_name,
+                table=TABLE,
+                mode="changes",
+                start_at=start_at,
+                on_exists="use",
+            ).open()
+
+        try:
+            consumer.window(max_snapshots=1)
+            consumer.connection.execute(
+                "SELECT * FROM cdc_consumer_release('lake', ?)", [consumer_name]
+            ).fetchall()
+        finally:
+            consumer.close()
+
+
+def _run_shape(*, attempts: int, workers: int, shared_connection: bool) -> int:
+    failures = 0
+    label = "shared" if shared_connection else "derived"
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(
+                _attempt,
+                shared_connection=shared_connection,
+                attempt=attempt,
+            ): attempt
+            for attempt in range(1, attempts + 1)
+        }
+        for future in as_completed(futures):
+            attempt = futures[future]
+            try:
+                future.result()
+            except Exception as exc:  # noqa: BLE001 - this is a reproducer
+                failures += 1
+                chain: list[str] = []
+                current: BaseException | None = exc
+                while current is not None:
+                    chain.append(f"{type(current).__name__}: {current}")
+                    current = current.__cause__
+                print(f"{label} attempt {attempt}: {' <- '.join(chain)}", flush=True)
+    print(f"{label}: {attempts - failures}/{attempts} succeeded", flush=True)
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--attempts", type=int, default=50)
+    parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument("--history", type=int, default=50)
+    parser.add_argument("--shape", choices=("shared", "derived", "both"), default="both")
+    parser.add_argument("--first-bootstrap-race", action="store_true")
+    args = parser.parse_args()
+    if args.attempts < 1:
+        parser.error("--attempts must be >= 1")
+
+    if args.workers < 1:
+        parser.error("--workers must be >= 1")
+    if args.history < 0:
+        parser.error("--history must be >= 0")
+
+    _prepare(history=args.history, bootstrap_cdc=not args.first_bootstrap_race)
+    try:
+        shared_failures = 0
+        derived_failures = 0
+        if args.shape in ("shared", "both"):
+            shared_failures = _run_shape(
+                attempts=args.attempts,
+                workers=args.workers,
+                shared_connection=True,
+            )
+        if args.shape in ("derived", "both"):
+            derived_failures = _run_shape(
+                attempts=args.attempts,
+                workers=args.workers,
+                shared_connection=False,
+            )
+    finally:
+        shutil.rmtree(E2E_DIR / ".work" / EXAMPLE, ignore_errors=True)
+
+    if args.shape == "both" and shared_failures and not derived_failures:
+        print("H-022 reproduced only on Atlas's shared catalogue connection shape")
+    return 0 if derived_failures == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/e2e/smoke/lease_multiconn_smoke.py
+++ b/e2e/smoke/lease_multiconn_smoke.py
@@ -8,8 +8,11 @@ process, and asserts:
 
 1. connection A acquires the lease via `cdc_window`
 2. connection B gets `CDC_BUSY` for the same consumer
-3. connection B force-releases the lease
-4. connection A's later `cdc_commit` gets `CDC_BUSY`
+3. connection A owner-conditionally releases its own lease
+4. connection B acquires the lease
+5. connection A cannot release connection B's lease
+6. connection B force-releases the lease as an operator action
+7. connection A's later `cdc_commit` gets `CDC_BUSY`
 
 Usage:
 
@@ -130,6 +133,10 @@ int main(int argc, char **argv) {
 	}
 
 	RequireError(b, "SELECT * FROM cdc_window('lake', 'multi_conn')", "CDC_BUSY");
+	RequireOk(a, "SELECT * FROM cdc_consumer_release('lake', 'multi_conn')");
+	RequireOk(b, "SELECT * FROM cdc_window('lake', 'multi_conn')");
+	RequireError(a, "SELECT * FROM cdc_consumer_release('lake', 'multi_conn')", "CDC_BUSY");
+	RequireOk(b, "SELECT * FROM cdc_consumer_heartbeat('lake', 'multi_conn')");
 	RequireOk(b, "SELECT * FROM cdc_consumer_force_release('lake', 'multi_conn')");
 	RequireError(a, "SELECT * FROM cdc_commit('lake', 'multi_conn', " + std::to_string(end_snapshot) + ")", "CDC_BUSY");
 

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -338,6 +338,12 @@ void CacheToken(duckdb::ClientContext &context, const std::string &catalog_name,
 	TOKEN_CACHE[TokenCacheKey(context, catalog_name, consumer_name)] = token;
 }
 
+void EraseCachedToken(duckdb::ClientContext &context, const std::string &catalog_name,
+                      const std::string &consumer_name) {
+	std::lock_guard<std::mutex> guard(TOKEN_CACHE_MUTEX);
+	TOKEN_CACHE.erase(TokenCacheKey(context, catalog_name, consumer_name));
+}
+
 void CacheDmlSafeCommitRange(duckdb::ClientContext &context, const std::string &catalog_name,
                              const std::string &consumer_name, int64_t cursor, int64_t safe_until) {
 	std::lock_guard<std::mutex> guard(DML_SAFE_COMMIT_MUTEX);
@@ -1375,6 +1381,78 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> ConsumerForceReleaseInit(du
 	auto result = duckdb::make_uniq<RowScanState>();
 	auto &data = input.bind_data->Cast<ConsumerForceReleaseData>();
 	result->rows.push_back(ForceReleaseConsumer(context, data));
+	return std::move(result);
+}
+
+//===--------------------------------------------------------------------===//
+// cdc_consumer_release
+//===--------------------------------------------------------------------===//
+
+void ThrowBusy(duckdb::Connection &conn, const std::string &catalog_name, const std::string &consumer_name);
+
+struct ConsumerReleaseData : public duckdb::TableFunctionData {
+	std::string catalog_name;
+	std::string consumer_name;
+
+	duckdb::unique_ptr<duckdb::FunctionData> Copy() const override {
+		auto result = duckdb::make_uniq<ConsumerReleaseData>();
+		result->catalog_name = catalog_name;
+		result->consumer_name = consumer_name;
+		return std::move(result);
+	}
+
+	bool Equals(const duckdb::FunctionData &other) const override {
+		return this == &other;
+	}
+};
+
+duckdb::unique_ptr<duckdb::FunctionData> ConsumerReleaseBind(duckdb::ClientContext &context,
+                                                             duckdb::TableFunctionBindInput &input,
+                                                             duckdb::vector<duckdb::LogicalType> &return_types,
+                                                             duckdb::vector<duckdb::string> &names) {
+	if (input.inputs.size() != 2) {
+		throw duckdb::BinderException("cdc_consumer_release requires catalog and consumer name");
+	}
+	auto result = duckdb::make_uniq<ConsumerReleaseData>();
+	result->catalog_name = GetStringArg(input.inputs[0], "catalog");
+	result->consumer_name = GetStringArg(input.inputs[1], "consumer name");
+
+	names = {"consumer_name", "consumer_id", "released_token"};
+	return_types = {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::BIGINT, duckdb::LogicalType::UUID};
+	return std::move(result);
+}
+
+std::vector<duckdb::Value> ReleaseConsumer(duckdb::ClientContext &context, const ConsumerReleaseData &data) {
+	duckdb::Connection conn(*context.db);
+	ConfigureCdcInternalConnection(conn);
+	CheckCatalogOrThrow(conn, data.catalog_name);
+	BootstrapConsumerStateOrThrow(conn, data.catalog_name);
+	const auto cached_token = CachedToken(context, data.catalog_name, data.consumer_name);
+	auto row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
+	if (cached_token.empty() || row.owner_token.IsNull() || row.owner_token.ToString() != cached_token) {
+		ThrowBusy(conn, data.catalog_name, data.consumer_name);
+	}
+
+	const auto consumers = StateTable(conn, data.catalog_name, CONSUMERS_TABLE);
+	ExecuteChecked(conn, "UPDATE " + consumers +
+	                         " SET owner_token = NULL, owner_acquired_at = NULL, owner_heartbeat_at = NULL, "
+	                         "updated_at = now() WHERE consumer_name = " +
+	                         QuoteLiteral(data.consumer_name) + " AND owner_token = " + TokenSqlOrNull(cached_token));
+	row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
+	if (!row.owner_token.IsNull()) {
+		ThrowBusy(conn, data.catalog_name, data.consumer_name);
+	}
+	EraseCachedToken(context, data.catalog_name, data.consumer_name);
+	const auto details = "{\"released_token\":\"" + JsonEscape(cached_token) + "\"}";
+	InsertAuditRow(conn, data.catalog_name, "consumer_release", data.consumer_name, row.consumer_id, details);
+	return {duckdb::Value(data.consumer_name), duckdb::Value::BIGINT(row.consumer_id), duckdb::Value(cached_token)};
+}
+
+duckdb::unique_ptr<duckdb::GlobalTableFunctionState> ConsumerReleaseInit(duckdb::ClientContext &context,
+                                                                         duckdb::TableFunctionInitInput &input) {
+	auto result = duckdb::make_uniq<RowScanState>();
+	auto &data = input.bind_data->Cast<ConsumerReleaseData>();
+	result->rows.push_back(ReleaseConsumer(context, data));
 	return std::move(result);
 }
 
@@ -3574,6 +3652,13 @@ void RegisterConsumerFunctions(duckdb::ExtensionLoader &loader) {
 		    name, duckdb::vector<duckdb::LogicalType> {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR},
 		    RowScanExecute, ConsumerForceReleaseBind, ConsumerForceReleaseInit);
 		loader.RegisterFunction(force_release_function);
+	}
+
+	for (const auto &name : {"cdc_consumer_release"}) {
+		duckdb::TableFunction release_function(
+		    name, duckdb::vector<duckdb::LogicalType> {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR},
+		    RowScanExecute, ConsumerReleaseBind, ConsumerReleaseInit);
+		loader.RegisterFunction(release_function);
 	}
 
 	for (const auto &name : {"cdc_consumer_heartbeat"}) {

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -69,6 +69,13 @@ bool CdcWindowData::Equals(const duckdb::FunctionData &other) const {
 
 namespace {
 
+bool IsH022TransientMessage(const std::string &message) {
+	const auto lower = duckdb::StringUtil::Lower(message);
+	return lower.find("resource deadlock avoided") != std::string::npos ||
+	       lower.find("resource deadlock would occur") != std::string::npos ||
+	       lower.find("thread::join failed") != std::string::npos;
+}
+
 //===--------------------------------------------------------------------===//
 // Forward declarations for the schema-shape pin enforcement helpers.
 // Definitions live further down in this translation unit; lifecycle paths
@@ -1039,7 +1046,7 @@ std::vector<ResolvedSubscriptionInput> ResolveCreateSubscriptions(duckdb::Connec
 	return ResolveDdlCreateSubscriptions(conn, catalog_name, data, snapshot_id);
 }
 
-std::vector<duckdb::Value> CreateConsumer(duckdb::ClientContext &context, const ConsumerCreateData &data) {
+std::vector<duckdb::Value> CreateConsumerOnce(duckdb::ClientContext &context, const ConsumerCreateData &data) {
 	// Open ONE connection up front so the version probe, the bootstrap
 	// CREATE writes, the start_at snapshot lookup, and the INSERTs all
 	// share a single SQLite file handle when the metadata catalog is
@@ -1148,6 +1155,20 @@ std::vector<duckdb::Value> CreateConsumer(duckdb::ClientContext &context, const 
 		}
 		throw;
 	}
+}
+
+std::vector<duckdb::Value> CreateConsumer(duckdb::ClientContext &context, const ConsumerCreateData &data) {
+	for (int attempt = 0; attempt < 5; ++attempt) {
+		try {
+			return CreateConsumerOnce(context, data);
+		} catch (const std::exception &ex) {
+			if (!IsH022TransientMessage(ex.what()) || attempt == 4) {
+				throw;
+			}
+			std::this_thread::sleep_for(std::chrono::milliseconds(200));
+		}
+	}
+	throw duckdb::InternalException("cdc consumer create retry loop exited unexpectedly");
 }
 
 duckdb::unique_ptr<duckdb::GlobalTableFunctionState> ConsumerCreateInit(duckdb::ClientContext &context,

--- a/src/ddl.cpp
+++ b/src/ddl.cpp
@@ -35,14 +35,36 @@
 #include "duckdb/main/materialized_query_result.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <climits>
 #include <sstream>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 
 namespace duckdb_cdc {
 
 namespace {
+
+duckdb::unique_ptr<duckdb::MaterializedQueryResult> QueryWithH022Retry(duckdb::Connection &conn,
+                                                                       const std::string &sql) {
+	duckdb::unique_ptr<duckdb::MaterializedQueryResult> result;
+	for (int attempt = 0; attempt < 5; ++attempt) {
+		result = conn.Query(sql);
+		if (result && !result->HasError()) {
+			return result;
+		}
+		const auto message = duckdb::StringUtil::Lower(result ? result->GetError() : std::string());
+		const bool h022 = message.find("resource deadlock avoided") != std::string::npos ||
+		                  message.find("resource deadlock would occur") != std::string::npos ||
+		                  message.find("thread::join failed") != std::string::npos;
+		if (!h022 || attempt == 4) {
+			return result;
+		}
+		std::this_thread::sleep_for(std::chrono::milliseconds(200));
+	}
+	return result;
+}
 
 //===--------------------------------------------------------------------===//
 // Token decoding for DDL extraction
@@ -1683,17 +1705,14 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcSchemaDiffInit(duckdb::C
 	// decides whether to skip itself (Phase 2 follow-up #1). Without
 	// dedup, a transaction that renames + alters the same table would
 	// emit two table_rename / per-column-diff blocks for one snapshot.
-	auto changes =
-	    conn.Query(std::string("SELECT s.snapshot_id, s.snapshot_time, e.key AS map_key, e.value AS map_values "
-	                           "FROM ") +
-	               QuoteIdentifier(data.catalog_name) +
-	               ".snapshots() s, "
-	               "UNNEST(map_entries(s.changes)) AS u(e) "
-	               "WHERE s.snapshot_id BETWEEN " +
-	               std::to_string(data.from_snapshot) + " AND " + std::to_string(data.to_snapshot) +
-	               " AND e.key IN ('tables_created', 'tables_altered') "
-	               "ORDER BY s.snapshot_id ASC, "
-	               "CASE e.key WHEN 'tables_created' THEN 0 ELSE 1 END");
+	const auto changes_sql =
+	    std::string("SELECT s.snapshot_id, s.snapshot_time, e.key AS map_key, e.value AS map_values FROM ") +
+	    QuoteIdentifier(data.catalog_name) +
+	    ".snapshots() s, UNNEST(map_entries(s.changes)) AS u(e) WHERE s.snapshot_id BETWEEN " +
+	    std::to_string(data.from_snapshot) + " AND " + std::to_string(data.to_snapshot) +
+	    " AND e.key IN ('tables_created', 'tables_altered') ORDER BY s.snapshot_id ASC, "
+	    "CASE e.key WHEN 'tables_created' THEN 0 ELSE 1 END";
+	auto changes = QueryWithH022Retry(conn, changes_sql);
 	if (!changes || changes->HasError()) {
 		throw duckdb::Exception(duckdb::ExceptionType::INVALID,
 		                        changes ? changes->GetError() : "cdc_schema_diff MAP scan failed");

--- a/src/ducklake_metadata.cpp
+++ b/src/ducklake_metadata.cpp
@@ -240,6 +240,7 @@ namespace {
 // at the listen call site.
 std::mutex STATE_SCHEMA_CACHE_MUTEX;
 std::unordered_set<std::string> STATE_SCHEMA_CACHE;
+std::mutex STATE_BOOTSTRAP_MUTEX;
 
 bool StateSchemaCacheLookup(const std::string &cache_key) {
 	if (cache_key.empty()) {
@@ -638,18 +639,48 @@ void BootstrapConsumerStateOrThrow(duckdb::Connection &conn, const std::string &
 	// CheckCatalogOrThrow is the caller's responsibility on this overload:
 	// every cdc_* function that follows the "open one conn, probe, bootstrap,
 	// then do work" pattern wants the version probe to share that conn too.
-	auto create_schema = conn.Query("CREATE SCHEMA IF NOT EXISTS " + MetadataDatabase(catalog_name) + "." +
-	                                QuoteIdentifier(STATE_SCHEMA));
-	const bool use_state_schema = create_schema && !create_schema->HasError();
-	ExecuteChecked(conn, ConsumersDdl(catalog_name, use_state_schema));
-	ExecuteChecked(conn, ConsumerSubscriptionsDdl(catalog_name, use_state_schema));
-	ExecuteChecked(conn, AuditDdl(catalog_name, use_state_schema));
-	if (use_state_schema) {
-		// Pre-warm the StateSchemaExists cache so subsequent listen calls
-		// in this process never have to re-probe the catalog enumerator.
+	//
+	// Do not issue idempotent DDL on every CDC call. Against a populated
+	// Postgres DuckLake catalog, concurrent CREATE IF NOT EXISTS and trigger
+	// installation from several outer ClientContexts can trip DuckDB/DuckLake's
+	// outer-to-inner catalog lock handoff (H-022). The authoritative zero-row
+	// state-table probe is sufficient once bootstrap has completed.
+	if (ProbeStateSchema(conn, catalog_name)) {
 		StateSchemaCacheRemember(MetadataAttachmentCacheKey(conn, catalog_name));
+		return;
 	}
-	InstallPostgresSnapshotNotifyBestEffort(conn, catalog_name);
+
+	// Only one connection in this process may perform first bootstrap. Recheck
+	// after taking the lock because another caller may have completed while we
+	// waited. Cross-process first bootstrap still relies on backend DDL
+	// idempotence and is documented separately under H-022.
+	std::lock_guard<std::mutex> bootstrap_guard(STATE_BOOTSTRAP_MUTEX);
+	if (ProbeStateSchema(conn, catalog_name)) {
+		StateSchemaCacheRemember(MetadataAttachmentCacheKey(conn, catalog_name));
+		return;
+	}
+	ExecuteChecked(conn, "BEGIN TRANSACTION");
+	try {
+		auto create_schema = conn.Query("CREATE SCHEMA IF NOT EXISTS " + MetadataDatabase(catalog_name) + "." +
+		                                QuoteIdentifier(STATE_SCHEMA));
+		const bool use_state_schema = create_schema && !create_schema->HasError();
+		ExecuteChecked(conn, ConsumersDdl(catalog_name, use_state_schema));
+		ExecuteChecked(conn, ConsumerSubscriptionsDdl(catalog_name, use_state_schema));
+		ExecuteChecked(conn, AuditDdl(catalog_name, use_state_schema));
+		InstallPostgresSnapshotNotifyBestEffort(conn, catalog_name);
+		ExecuteChecked(conn, "COMMIT");
+		if (use_state_schema) {
+			// Pre-warm the StateSchemaExists cache only after the DDL is
+			// committed and visible to other DatabaseInstance connections.
+			StateSchemaCacheRemember(MetadataAttachmentCacheKey(conn, catalog_name));
+		}
+	} catch (...) {
+		try {
+			ExecuteChecked(conn, "ROLLBACK");
+		} catch (...) {
+		}
+		throw;
+	}
 }
 
 void BootstrapConsumerStateOrThrow(duckdb::ClientContext &context, const std::string &catalog_name) {

--- a/test/consumer_lifecycle.test
+++ b/test/consumer_lifecycle.test
@@ -64,6 +64,20 @@ FROM cdc_consumer_heartbeat('lake', 'items_sink');
 true
 
 query I
+SELECT released_token IS NOT NULL
+FROM cdc_consumer_release('lake', 'items_sink');
+----
+true
+
+statement error
+SELECT * FROM cdc_consumer_heartbeat('lake', 'items_sink');
+----
+CDC_BUSY
+
+statement ok
+SELECT * FROM cdc_window('lake', 'items_sink');
+
+query I
 SELECT previous_token IS NOT NULL
 FROM cdc_consumer_force_release('lake', 'items_sink');
 ----

--- a/test/version_and_load.test
+++ b/test/version_and_load.test
@@ -15,7 +15,7 @@ require ducklake_cdc
 query I
 SELECT cdc_version();
 ----
-ducklake_cdc 0.5.3
+ducklake_cdc 0.5.4
 
 query I
 SELECT length(cdc_build_revision()) > 0;


### PR DESCRIPTION
## What changed

- adds `cdc_consumer_release(catalog, name)`, which clears a lease only when the calling connection's cached owner token still matches
- keeps `cdc_consumer_force_release` as the unconditional operator recovery primitive
- skips repeated consumer-state DDL for populated catalogs, serializes genuine first bootstrap in-process, and commits bootstrap DDL before caching it
- adds an Atlas-shaped Postgres H-022 stress reproducer and multi-connection ownership regression coverage
- bumps the extension to 0.5.4

## Why

Atlas catalogue workers exposed two failure modes: stale process leases were being cleared with an unsafe unconditional force-release, and concurrent consumer setup on a populated Postgres DuckLake catalog intermittently surfaced `Resource deadlock avoided`. The extension was rerunning idempotent schema/table/trigger DDL on every setup, multiplying the outer ClientContext to internal Connection lock handoff.

The populated-catalog mitigation passes 100/100 attempts for both shared and derived shapes. A fresh concurrent first-bootstrap race still reproduces `thread::join failed: Invalid argument` on the shared shape (1/16), while the derived-connection control passes 16/16; that remaining core handoff will be escalated upstream.

## Validation

- release build
- format check with clang-format 11.0.1
- full SQLLogicTest suite: 308 assertions across 11 test cases
- owner-token multi-connection smoke
- Ruff on the H-022 reproducer
- populated Postgres stress: shared 100/100, derived 100/100
- fresh first-bootstrap stress: shared 15/16, derived 16/16 (expected upstream defect reproduction)
