### PR TITLE
Add catalogue-wide DML tick consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(TARGET_NAME ducklake_cdc)
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
-project(${TARGET_NAME} VERSION 0.5.4)
+project(${TARGET_NAME} VERSION 0.6.0)
 
 set(CMAKE_CXX_STANDARD "17" CACHE STRING "C++ standard to enforce")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,28 @@ SELECT *
 FROM cdc_commit('lake', 'orders_sink', <batch_end_snapshot>);
 ```
 
+Create one catalogue-wide cursor when only schema-independent DML ticks are
+needed:
+
+```sql
+SELECT *
+FROM cdc_dml_consumer_create(
+  'lake',
+  'catalog_dml_ticks',
+  start_at := 'now'
+);
+
+SELECT *
+FROM cdc_dml_ticks_listen(
+  'lake',
+  'catalog_dml_ticks',
+  timeout_ms := 1000
+);
+```
+
+Each tick carries the touched `table_ids`. The same cursor follows future
+tables and crosses DDL boundaries; fan-out belongs downstream.
+
 Listen for schema changes:
 
 ```sql

--- a/docs/api.md
+++ b/docs/api.md
@@ -74,7 +74,7 @@ SELECT cdc_version();
 Returns the loaded extension version as a scalar `VARCHAR`.
 
 The value is the stable semantic release version, for example
-`ducklake_cdc 0.5.4`. Use `cdc_build_revision()` when an exact source/build
+`ducklake_cdc 0.6.0`. Use `cdc_build_revision()` when an exact source/build
 identity is required.
 
 Use it in support tickets, CI logs, benchmark output, and migration checks.
@@ -296,20 +296,19 @@ FROM cdc_dml_consumer_create(
 );
 ```
 
-Creates a durable DML consumer pinned to **exactly one** concrete table
-identity. Pass exactly one of `table_name` or `table_id`; the bind
-rejects "both set" and "neither set".
+Creates a durable DML consumer. Pass exactly one of `table_name` or
+`table_id` for row changes, or omit both for a catalogue-wide tick consumer.
+Passing both is always invalid, and `change_types` requires a table identity.
 
-Multi-table fan-out is **not** part of the DML consumer contract. It
-belongs to the orchestrator: spawn one DML consumer per table and join
-downstream of the sinks. This keeps the schema-shape termination
-contract crisp — when the pinned table's shape changes, that one
-consumer hard-stops and the orchestrator spawns a successor at the
-boundary snapshot.
+Catalogue-wide DML consumers work with `cdc_dml_ticks_read` and
+`cdc_dml_ticks_listen`. Their schema-independent tick rows contain the touched
+`table_ids`, follow future tables automatically, and continue across DDL
+boundaries. They intentionally cannot call `cdc_dml_changes_*`, whose dynamic
+row projection requires exactly one table identity.
 
-DML consumers do not dynamically subscribe to future tables through schema or
-catalog filters. That policy belongs in application code, usually driven by a
-separate DDL consumer.
+Table-scoped DML consumers retain the schema-shape termination contract: when
+the pinned table's shape changes, that consumer hard-stops and the orchestrator
+creates a successor at the boundary snapshot.
 
 Name input is resolved at `start_at` and persisted as `table_id`. For
 `start_at := 'beginning'`, `'oldest'`, or `'oldest_available'`, DML creation
@@ -677,11 +676,10 @@ change_count BIGINT
 
 ## Stateful DML
 
-DML consumers are pinned to exactly one table by contract (see
-`cdc_dml_consumer_create`). The DML payload API is therefore unified:
-there is one read/listen pair, and rows project the pinned table's
-**native columns** at the top level — no separate "table changes"
-function and no JSON `values` blob.
+Table-scoped DML consumers expose one row-level read/listen pair whose rows
+project the pinned table's **native columns** at the top level—no separate
+"table changes" function and no JSON `values` blob. Catalogue-wide DML
+consumers expose ticks only.
 
 All DML listen functions auto-advance through *non-terminal* empty windows.
 A window is non-terminal when `cdc_window` reports `has_changes = true` but

--- a/docs/development.md
+++ b/docs/development.md
@@ -170,7 +170,7 @@ Release. Asset names include the extension version, DuckDB version, and DuckDB
 platform, for example:
 
 ```text
-ducklake_cdc-v0.5.4-duckdb-v1.5.4-linux_arm64.duckdb_extension
+ducklake_cdc-v0.6.0-duckdb-v1.5.4-linux_arm64.duckdb_extension
 ```
 
 `SHA256SUMS` in the same release pins their contents. These maintainer release

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -44,9 +44,10 @@ extension knows how to read safely.
 
 ### `CDC_SCHEMA_TERMINATED`
 
-A DML consumer is pinned to the schema shape of its subscribed table at
-creation time (one DML consumer = one table by contract). The shape is
-the column set the table has at the consumer's
+A table-scoped DML consumer is pinned to the schema shape of its subscribed
+table at creation time. Catalogue-wide tick consumers do not have a row
+schema and do not terminate at DDL boundaries. For a table-scoped consumer,
+the shape is the column set the table has at the consumer's
 `last_committed_snapshot`. Once the subscribed table is altered,
 dropped, or has its containing schema dropped, the consumer terminates:
 it stops returning DML and its cursor is parked at the snapshot before

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -605,8 +605,8 @@ struct ConsumerCreateData : public duckdb::TableFunctionData {
 	duckdb::Value schema_ids;
 	duckdb::Value table_names;
 	duckdb::Value table_ids;
-	// DML-only scope inputs (one DML consumer = one table). Exactly one
-	// of {table_name, table_id} must be set on cdc_dml_consumer_create.
+	// DML scope inputs. A table identity pins row-level change consumers;
+	// omitting both creates a catalog-wide, tick-only consumer.
 	duckdb::Value table_name;
 	duckdb::Value table_id;
 	duckdb::Value change_types;
@@ -712,9 +712,8 @@ duckdb::unique_ptr<duckdb::FunctionData> DmlConsumerCreateBind(duckdb::ClientCon
 	result->consumer_name = GetStringArg(input.inputs[1], "consumer name");
 	result->consumer_kind = "dml";
 	result->start_at = StartAtParameter(input);
-	// One DML consumer = one table. We accept either `table_name` or
-	// `table_id` so callers can pin to identity (id) or convenience
-	// (name); both being set is a configuration error.
+	// A table identity pins row-level change consumers; omitting both
+	// creates a catalog-wide cursor for schema-independent DML ticks.
 	result->table_name = NamedParameterValue(input, "table_name");
 	result->table_id = NamedParameterValue(input, "table_id");
 	result->change_types = NamedParameterValue(input, "change_types");
@@ -723,9 +722,10 @@ duckdb::unique_ptr<duckdb::FunctionData> DmlConsumerCreateBind(duckdb::ClientCon
 		throw duckdb::InvalidInputException(
 		    "cdc_dml_consumer_create: pass exactly one of `table_name` or `table_id`, not both");
 	}
-	if (result->table_name.IsNull() && result->table_id.IsNull()) {
+	if (result->table_name.IsNull() && result->table_id.IsNull() && !result->change_types.IsNull()) {
 		throw duckdb::InvalidInputException(
-		    "cdc_dml_consumer_create: requires `table_name` or `table_id` (one DML consumer = one table)");
+		    "cdc_dml_consumer_create: `change_types` requires `table_name` or `table_id`; "
+		    "catalog-wide consumers emit DML ticks only");
 	}
 	ConsumerCreateReturnTypes(return_types, names);
 	return std::move(result);
@@ -944,16 +944,18 @@ void AddResolvedSubscription(std::vector<ResolvedSubscriptionInput> &out, const 
 	out.push_back(std::move(sub));
 }
 
-//! Resolve the single table identity that a DML consumer is being pinned
-//! to, fan out one base subscription per requested change_type. Bind has
-//! already enforced that exactly one of `data.table_name` /
-//! `data.table_id` is set; this function just turns identity inputs into
-//! `(schema_id, table_id, current qualified name)` and emits the
-//! per-change-type subscription rows.
+//! Resolve a DML consumer scope. Omitting table identity creates one
+//! catalog-wide subscription for schema-independent ticks. A table-scoped
+//! consumer fans out one subscription per requested row change type.
 std::vector<ResolvedSubscriptionInput> ResolveDmlCreateSubscriptions(duckdb::Connection &conn,
                                                                      const std::string &catalog_name,
                                                                      const ConsumerCreateData &data,
                                                                      int64_t snapshot_id) {
+	if (data.table_name.IsNull() && data.table_id.IsNull()) {
+		std::vector<ResolvedSubscriptionInput> out;
+		AddResolvedSubscription(out, "catalog", duckdb::Value(), duckdb::Value(), "dml", "*", duckdb::Value());
+		return out;
+	}
 	const auto change_types = DmlChangeTypeList(data.change_types);
 	int64_t schema_id = 0;
 	int64_t table_id = 0;
@@ -2487,6 +2489,15 @@ bool DmlSubscriptionsIncludeTable(const std::vector<ConsumerSubscriptionRow> &su
 	return false;
 }
 
+bool HasCatalogDmlSubscription(const std::vector<ConsumerSubscriptionRow> &subscriptions) {
+	for (const auto &subscription : subscriptions) {
+		if (subscription.event_category == "dml" && subscription.scope_kind == "catalog") {
+			return true;
+		}
+	}
+	return false;
+}
+
 void DmlSubscriptionIds(const std::vector<ConsumerSubscriptionRow> &subscriptions,
                         std::unordered_set<int64_t> &table_ids, std::unordered_set<int64_t> &schema_ids) {
 	for (const auto &subscription : subscriptions) {
@@ -2515,14 +2526,15 @@ bool SnapshotChangeTouchesDmlTables(const DecodedSnapshotChange &change, const s
 int64_t FirstDmlSubscribedSnapshot(duckdb::Connection &conn, const std::string &catalog_name, int64_t start_snapshot,
                                    int64_t current_snapshot,
                                    const std::vector<ConsumerSubscriptionRow> &dml_subscriptions) {
+	const auto catalog_wide = HasCatalogDmlSubscription(dml_subscriptions);
 	std::unordered_set<int64_t> table_ids;
 	std::unordered_set<int64_t> schema_ids;
 	DmlSubscriptionIds(dml_subscriptions, table_ids, schema_ids);
-	if (table_ids.empty()) {
+	if (!catalog_wide && table_ids.empty()) {
 		return -1;
 	}
 	for (const auto &change : LoadDecodedSnapshotChanges(conn, catalog_name, start_snapshot, current_snapshot)) {
-		if (SnapshotChangeTouchesDmlTables(change, table_ids)) {
+		if ((catalog_wide && !change.dml_table_ids.empty()) || SnapshotChangeTouchesDmlTables(change, table_ids)) {
 			return change.snapshot_id;
 		}
 	}
@@ -2575,6 +2587,9 @@ bool DmlTableChangesMatchSubscriptions(duckdb::Connection &conn, const std::stri
 	const auto change_types = MatchingDmlChangeTypes(subscriptions, schema_id, table_id);
 	if (change_types.empty()) {
 		return false;
+	}
+	if (std::find(change_types.begin(), change_types.end(), "*") != change_types.end()) {
+		return true;
 	}
 	const auto dot = qualified_name.find('.');
 	if (dot == std::string::npos) {
@@ -3181,8 +3196,7 @@ std::vector<ConsumerSubscriptionRow> LoadDmlConsumerSubscriptions(duckdb::Connec
 	      << "s.event_category, s.change_type, s.original_qualified_name, c.consumer_kind FROM "
 	      << StateTable(conn, catalog_name, CONSUMERS_TABLE) << " c JOIN "
 	      << StateTable(conn, catalog_name, CONSUMER_SUBSCRIPTIONS_TABLE) << " s ON s.consumer_id = c.consumer_id "
-	      << "WHERE c.consumer_name = " << QuoteLiteral(consumer_name)
-	      << " AND s.event_category = 'dml' AND s.scope_kind = 'table' AND s.table_id IS NOT NULL "
+	      << "WHERE c.consumer_name = " << QuoteLiteral(consumer_name) << " AND s.event_category = 'dml' "
 	      << "ORDER BY c.consumer_id ASC, s.subscription_id ASC";
 	auto result = conn.Query(query.str());
 	if (!result || result->HasError()) {
@@ -3645,8 +3659,8 @@ void RegisterConsumerFunctions(duckdb::ExtensionLoader &loader) {
 	    duckdb::vector<duckdb::LogicalType> {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR},
 	    RowScanExecute, DmlConsumerCreateBind, ConsumerCreateInit);
 	dml_create_function.named_parameters["start_at"] = duckdb::LogicalType::VARCHAR;
-	// Scalar (singular) — one DML consumer = one table. Pass exactly one
-	// of `table_name` or `table_id`; bind rejects both-set / neither-set.
+	// Scalar table identity is optional. Pass exactly one of `table_name`
+	// or `table_id` for row changes, or omit both for catalog-wide ticks.
 	dml_create_function.named_parameters["table_name"] = duckdb::LogicalType::VARCHAR;
 	dml_create_function.named_parameters["table_id"] = duckdb::LogicalType::BIGINT;
 	dml_create_function.named_parameters["change_types"] = varchar_list;

--- a/src/dml.cpp
+++ b/src/dml.cpp
@@ -301,8 +301,10 @@ void AppendDmlTickRows(duckdb::Connection &conn, const std::string &catalog_name
 			if (subscriptions != nullptr) {
 				bool covered = false;
 				for (const auto &subscription : *subscriptions) {
-					if (subscription.event_category == "dml" && subscription.scope_kind == "table" &&
-					    !subscription.table_id.IsNull() && subscription.table_id.GetValue<int64_t>() == table_id) {
+					if (subscription.event_category == "dml" &&
+					    (subscription.scope_kind == "catalog" ||
+					     (subscription.scope_kind == "table" && !subscription.table_id.IsNull() &&
+					      subscription.table_id.GetValue<int64_t>() == table_id))) {
 						covered = true;
 						break;
 					}
@@ -1263,9 +1265,9 @@ void RegisterDmlFunctions(duckdb::ExtensionLoader &loader) {
 		loader.RegisterFunction(events_function);
 	}
 
-	// Single, typed DML row-level read/listen surface. The consumer's
-	// pinned table is implicit (one DML consumer = one table); there is
-	// no `table_id` / `table_name` override knob.
+	// Single, typed DML row-level read/listen surface. A table-scoped
+	// consumer's pinned table is implicit; catalogue-wide consumers are
+	// rejected because they have no stable row schema.
 	for (const auto &name : {"cdc_dml_changes_read", "cdc_dml_changes_listen"}) {
 		const auto bind =
 		    std::string(name).find("_listen") == std::string::npos ? CdcChangesReadBind : CdcChangesListenBind;

--- a/src/include/consumer.hpp
+++ b/src/include/consumer.hpp
@@ -27,16 +27,16 @@ namespace duckdb_cdc {
 //! Single row from the `__ducklake_cdc_consumers` state table, normalised
 //! into typed fields. Cross-cutting routing intent (schema_id, change_type
 //! filters, rename/drop status) lives in
-//! `__ducklake_cdc_consumer_subscriptions`. The single subscribed
-//! `table_id` is denormalised onto this row because every DML consumer
-//! has exactly one table — it lets `cdc_list_consumers` and the
-//! per-listen hot path resolve the table without a join.
+//! `__ducklake_cdc_consumer_subscriptions`. A table-scoped DML consumer's
+//! subscribed `table_id` is denormalised onto this row so
+//! `cdc_list_consumers` and the row-level hot path can resolve it without a
+//! join. Catalogue-wide tick consumers leave it NULL.
 struct ConsumerRow {
 	std::string consumer_name;
 	std::string consumer_kind;
 	int64_t consumer_id;
-	//! Subscribed table_id. Populated for DML consumers (always exactly
-	//! one); always NULL for DDL consumers.
+	//! Subscribed table_id. Populated for table-scoped DML consumers;
+	//! NULL for catalogue-wide DML tick consumers and DDL consumers.
 	duckdb::Value table_id;
 	int64_t last_committed_snapshot;
 	int64_t last_committed_schema_version;

--- a/src/include/dml.hpp
+++ b/src/include/dml.hpp
@@ -5,9 +5,9 @@
 //
 // Row-level change-event surface. Owns cdc_dml_ticks_read (snapshot-by-
 // snapshot commit metadata filtered by consumer subscriptions),
-// cdc_dml_changes_read / cdc_dml_changes_listen (typed DML rows from the
-// consumer's pinned table — one DML consumer = one table — projected
-// through subscription change-type rules), and the stateless
+// cdc_dml_changes_read / cdc_dml_changes_listen (typed DML rows from a
+// table-scoped consumer, projected through subscription change-type rules),
+// and the stateless
 // cdc_dml_changes_query sugar for ad-hoc single-table lookback.
 //===----------------------------------------------------------------------===//
 

--- a/test/dml_ticks.test
+++ b/test/dml_ticks.test
@@ -109,3 +109,67 @@ snapshot_id	BIGINT
 snapshot_time	TIMESTAMP WITH TIME ZONE
 schema_version	BIGINT
 table_ids	BIGINT[]
+
+statement ok
+SELECT * FROM cdc_dml_consumer_create(
+  'lake',
+  'catalog_ticks',
+  start_at := 'beginning'
+);
+
+query I
+SELECT count(DISTINCT table_id)
+FROM (
+  SELECT unnest(table_ids) AS table_id
+  FROM cdc_dml_ticks_read(
+    'lake',
+    'catalog_ticks',
+    max_snapshots := 1000
+  )
+);
+----
+2
+
+statement error
+SELECT * FROM cdc_dml_changes_read(
+  'lake',
+  'catalog_ticks',
+  max_snapshots := 1000
+);
+----
+no DML table subscription
+
+statement ok
+SET VARIABLE catalog_ticks_head = (
+  SELECT max(snapshot_id) FROM __ducklake_metadata_lake.ducklake_snapshot
+);
+
+statement ok
+SELECT * FROM cdc_commit(
+  'lake',
+  'catalog_ticks',
+  getvariable('catalog_ticks_head')
+);
+
+statement ok
+ALTER TABLE lake.orders ADD COLUMN note VARCHAR;
+
+statement ok
+INSERT INTO lake.orders(id, status, note)
+VALUES (3, 'shipped', 'catalog cursor survived DDL');
+
+query I
+SELECT count(*) >= 1
+FROM cdc_dml_ticks_read(
+  'lake',
+  'catalog_ticks',
+  max_snapshots := 1000
+);
+----
+true
+
+query TT
+SELECT terminal, schema_changes_pending
+FROM cdc_window('lake', 'catalog_ticks', max_snapshots := 1000);
+----
+false	false

--- a/test/version_and_load.test
+++ b/test/version_and_load.test
@@ -15,7 +15,7 @@ require ducklake_cdc
 query I
 SELECT cdc_version();
 ----
-ducklake_cdc 0.5.4
+ducklake_cdc 0.6.0
 
 query I
 SELECT length(cdc_build_revision()) > 0;


### PR DESCRIPTION
Adds one catalogue-wide DML tick cursor that emits touched table IDs, follows new tables, and crosses DDL boundaries. Row-level change reads remain pinned to one table.

Validation:
- format check
- release build with DuckDB 1.5.4
- full SQL suite: 318 assertions across 11 tests
- regression coverage for multiple tables and ALTER TABLE survival