### PR TITLE
Fix PostgreSQL consumer progress and idle reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
         run: |
           docker compose -f e2e/docker-compose.yml up -d --wait
           trap 'docker compose -f e2e/docker-compose.yml down -v' EXIT
+          uv run --project e2e --locked python e2e/smoke/ddl_postgres_listener_progress_smoke.py
           uv run --project e2e --locked python e2e/ci_demo_assertions.py
 
   upstream-contract-check:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(TARGET_NAME ducklake_cdc)
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
-project(${TARGET_NAME} VERSION 0.6.0)
+project(${TARGET_NAME} VERSION 0.6.1)
 
 set(CMAKE_CXX_STANDARD "17" CACHE STRING "C++ standard to enforce")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/docs/api.md
+++ b/docs/api.md
@@ -74,7 +74,7 @@ SELECT cdc_version();
 Returns the loaded extension version as a scalar `VARCHAR`.
 
 The value is the stable semantic release version, for example
-`ducklake_cdc 0.6.0`. Use `cdc_build_revision()` when an exact source/build
+`ducklake_cdc 0.6.1`. Use `cdc_build_revision()` when an exact source/build
 identity is required.
 
 Use it in support tickets, CI logs, benchmark output, and migration checks.
@@ -572,6 +572,12 @@ FROM cdc_ddl_changes_listen(
 Waits until DDL changes matching the consumer are available or the deadline is
 reached, then returns parsed DDL changes.
 
+When catalog activity contains no DDL matching this consumer, both stateful
+read and listen durably advance the cursor through the inspected snapshots and
+may return an empty result. This is internal no-op acknowledgement, not
+`auto_commit`: a non-empty DDL result remains caller-committed unless
+`auto_commit := TRUE`.
+
 `poll_min_ms` controls the initial polling interval for backends without an
 event wakeup path (or when the wakeup path is unavailable). The interval
 backs off exponentially after each empty probe. PostgreSQL catalogs use the
@@ -799,6 +805,12 @@ FROM cdc_dml_ticks_read(
 ```
 
 Reads DML-relevant snapshot ticks for the consumer without waiting.
+
+For PostgreSQL-backed catalogues, a consumer already at catalogue head is
+resolved with a native bounded head probe. The steady-state empty read does
+not copy the full DuckLake snapshot metadata history through DuckDB's
+Postgres scanner. This is an empty-read optimization only; the next non-empty
+tick remains caller-committed unless `auto_commit := TRUE`.
 
 Returns:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -170,7 +170,7 @@ Release. Asset names include the extension version, DuckDB version, and DuckDB
 platform, for example:
 
 ```text
-ducklake_cdc-v0.6.0-duckdb-v1.5.4-linux_arm64.duckdb_extension
+ducklake_cdc-v0.6.1-duckdb-v1.5.4-linux_arm64.duckdb_extension
 ```
 
 `SHA256SUMS` in the same release pins their contents. These maintainer release

--- a/e2e/smoke/README.md
+++ b/e2e/smoke/README.md
@@ -47,3 +47,17 @@ uv run python e2e/smoke/enumerate_changes_map.py --backends duckdb sqlite postgr
 
 The script sets `DATA_INLINING_ROW_LIMIT = 10` explicitly (DuckLake's spec default)
 so inlined-data boundary checks stay deterministic across local runs and CI.
+
+## PostgreSQL consumer progress
+
+`ddl_postgres_listener_progress_smoke.py` guards the catalogue-relay workload:
+caught-up DDL read and listen calls must durably skip a new DML-only snapshot
+without sequentially rereading the complete Postgres snapshot metadata
+history, and must still deliver the next real DDL event. It also verifies that
+a caught-up non-blocking DML tick read uses a bounded head probe instead of a
+complete snapshot-table copy, while leaving the next real tick caller-committed.
+
+```bash
+docker compose -f e2e/docker-compose.yml up -d --wait postgres
+uv run --project e2e python e2e/smoke/ddl_postgres_listener_progress_smoke.py
+```

--- a/e2e/smoke/ddl_postgres_listener_progress_smoke.py
+++ b/e2e/smoke/ddl_postgres_listener_progress_smoke.py
@@ -1,0 +1,202 @@
+"""Postgres regression for DDL listener progress and bounded metadata reads.
+
+Requires the e2e Postgres service:
+
+    docker compose -f e2e/docker-compose.yml up -d --wait postgres
+    uv run --project e2e python e2e/smoke/ddl_postgres_listener_progress_smoke.py
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import shutil
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeVar
+
+import duckdb
+import psycopg
+from _harness_env import CDC_EXTENSION
+
+PG_DSN = "postgresql://ducklake:ducklake@localhost:5436/ducklake"
+HISTORY_SNAPSHOTS = 300
+T = TypeVar("T")
+
+
+def reset_catalog() -> None:
+    with psycopg.connect(PG_DSN) as pg:
+        pg.execute('DROP SCHEMA IF EXISTS "__ducklake_cdc" CASCADE')
+        pg.execute("DROP SCHEMA IF EXISTS public CASCADE")
+        pg.execute("CREATE SCHEMA public")
+        pg.commit()
+
+
+def capture_postgres_queries(con: duckdb.DuckDBPyConnection, action: Callable[[], T]) -> tuple[T, str]:
+    """Capture SQL emitted by DuckDB's Postgres scanner for one action."""
+
+    con.execute("SET pg_debug_show_queries = true")
+    with tempfile.TemporaryFile(mode="w+b") as captured:
+        stdout = os.dup(1)
+        stderr = os.dup(2)
+        os.dup2(captured.fileno(), 1)
+        os.dup2(captured.fileno(), 2)
+        try:
+            result = action()
+            ctypes.CDLL(None).fflush(None)
+        finally:
+            os.dup2(stdout, 1)
+            os.dup2(stderr, 2)
+            os.close(stdout)
+            os.close(stderr)
+            con.execute("SET pg_debug_show_queries = false")
+        captured.seek(0)
+        queries = captured.read().decode(errors="replace")
+    return result, queries
+
+
+def full_snapshot_copies(queries: str) -> list[str]:
+    copies = []
+    for raw_statement in queries.split("\n\n"):
+        statement = raw_statement.strip()
+        if not statement.startswith("COPY (SELECT") or not (
+            '"ducklake_snapshot"' in statement
+            or '"ducklake_snapshot_changes"' in statement
+        ):
+            continue
+        _, separator, predicate = statement.upper().partition(" WHERE ")
+        if not separator or "SNAPSHOT_ID" not in predicate:
+            copies.append(statement)
+    return copies
+
+
+def durable_cursor(consumer_name: str) -> tuple[int, int]:
+    with psycopg.connect(PG_DSN) as pg:
+        row = pg.execute(
+            """
+            SELECT c.last_committed_snapshot,
+                   (SELECT max(snapshot_id) FROM public.ducklake_snapshot)
+            FROM __ducklake_cdc.__ducklake_cdc_consumers c
+            WHERE c.consumer_name = %s
+            """,
+            (consumer_name,),
+        ).fetchone()
+        assert row is not None
+        return int(row[0]), int(row[1])
+
+
+def main() -> None:
+    reset_catalog()
+    with tempfile.TemporaryDirectory(prefix="ducklake_cdc_ddl_pg_") as tmp:
+        data_path = Path(tmp) / "data"
+        shutil.rmtree(data_path, ignore_errors=True)
+        data_path.mkdir()
+
+        con = duckdb.connect(config={"allow_unsigned_extensions": True, "threads": 1})
+        try:
+            con.execute("INSTALL postgres; LOAD postgres; INSTALL ducklake; LOAD ducklake;")
+            con.load_extension(str(CDC_EXTENSION))
+            con.execute(f"ATTACH 'ducklake:postgres:{PG_DSN}' AS lake (DATA_PATH '{data_path.as_posix()}')")
+            con.execute("SELECT cdc_version()")
+            con.execute("SELECT count(*) FROM cdc_list_consumers('lake')")
+            con.execute("CREATE TABLE lake.items(id BIGINT)")
+            con.execute("SELECT * FROM cdc_ddl_consumer_create('lake', 'ddl_scan', start_at := 'now')")
+
+            for value in range(HISTORY_SNAPSHOTS):
+                con.execute("INSERT INTO lake.items VALUES (?)", [value])
+
+            # Drain the initial history first. The transport assertion below
+            # measures the steady-state case that regressed in Atlas: one new
+            # DML snapshot waking a caught-up DDL listener.
+            rows = con.execute("SELECT * FROM cdc_ddl_changes_listen('lake', 'ddl_scan', timeout_ms := 0)").fetchall()
+            assert rows == []
+            assert durable_cursor("ddl_scan")[0] == durable_cursor("ddl_scan")[1]
+
+            con.execute("INSERT INTO lake.items VALUES (?)", [HISTORY_SNAPSHOTS])
+            rows = con.execute(
+                "SELECT * FROM cdc_ddl_changes_listen('lake', 'ddl_scan', timeout_ms := 0)"
+            ).fetchall()
+            assert rows == []
+
+            cursor, head = durable_cursor("ddl_scan")
+            assert cursor == head, (cursor, head)
+
+            # Advancing empty DML windows must not consume the next real DDL.
+            con.execute("ALTER TABLE lake.items ADD COLUMN tag VARCHAR")
+            ddl_rows = con.execute(
+                "SELECT event_kind, object_kind, object_name, end_snapshot FROM cdc_ddl_changes_listen('lake', 'ddl_scan', timeout_ms := 0)"
+            ).fetchall()
+            assert len(ddl_rows) == 1, ddl_rows
+            assert ddl_rows[0][:3] == ("altered", "table", "items"), ddl_rows
+            assert durable_cursor("ddl_scan")[0] < durable_cursor("ddl_scan")[1]
+            con.execute(
+                "SELECT * FROM cdc_commit('lake', 'ddl_scan', ?)",
+                [ddl_rows[0][3]],
+            )
+
+            # Atlas uses the non-blocking read entry point. It must have the
+            # same bounded metadata access and empty-window progress semantics.
+            con.execute("SELECT * FROM cdc_ddl_consumer_create('lake', 'ddl_read_scan', start_at := 'now')")
+            con.execute("INSERT INTO lake.items VALUES (?, NULL)", [HISTORY_SNAPSHOTS + 1])
+            rows = con.execute("SELECT * FROM cdc_ddl_changes_read('lake', 'ddl_read_scan')").fetchall()
+            assert rows == []
+            read_cursor, read_head = durable_cursor("ddl_read_scan")
+            assert read_cursor == read_head, (read_cursor, read_head)
+
+            con.execute("ALTER TABLE lake.items ADD COLUMN score INTEGER")
+            read_ddl_rows = con.execute(
+                "SELECT event_kind, object_kind, object_name, end_snapshot "
+                "FROM cdc_ddl_changes_read('lake', 'ddl_read_scan')"
+            ).fetchall()
+            assert len(read_ddl_rows) == 1, read_ddl_rows
+            assert read_ddl_rows[0][:3] == ("altered", "table", "items"), read_ddl_rows
+            assert durable_cursor("ddl_read_scan")[0] < durable_cursor("ddl_read_scan")[1]
+            con.execute(
+                "SELECT * FROM cdc_commit('lake', 'ddl_read_scan', ?)",
+                [read_ddl_rows[0][3]],
+            )
+
+            # Atlas's global DML relay also polls with non-blocking read. At
+            # the catalogue head that probe must not fall through to a full
+            # DuckLake metadata window scan.
+            con.execute("SELECT * FROM cdc_dml_consumer_create('lake', 'dml_read_scan', start_at := 'now')")
+            dml_rows: list[tuple] = []
+
+            def poll_dml_head() -> None:
+                nonlocal dml_rows
+                for _ in range(10):
+                    dml_rows = con.execute(
+                        "SELECT * FROM cdc_dml_ticks_read('lake', 'dml_read_scan')"
+                    ).fetchall()
+
+            _, dml_read_queries = capture_postgres_queries(con, poll_dml_head)
+            assert dml_rows == []
+            dml_cursor, dml_head = durable_cursor("dml_read_scan")
+            assert dml_cursor == dml_head, (dml_cursor, dml_head)
+            dml_full_copies = full_snapshot_copies(dml_read_queries)
+            assert dml_full_copies == [], dml_full_copies
+
+            # The probe is only an idle fast path. The next matching DML tick
+            # remains caller-committed.
+            con.execute("INSERT INTO lake.items VALUES (?, NULL, NULL)", [HISTORY_SNAPSHOTS + 2])
+            dml_rows = con.execute(
+                "SELECT table_ids, end_snapshot FROM cdc_dml_ticks_read('lake', 'dml_read_scan')"
+            ).fetchall()
+            assert len(dml_rows) == 1, dml_rows
+            assert durable_cursor("dml_read_scan")[0] < durable_cursor("dml_read_scan")[1]
+            con.execute(
+                "SELECT * FROM cdc_commit('lake', 'dml_read_scan', ?)",
+                [dml_rows[0][1]],
+            )
+        finally:
+            con.close()
+
+    print(
+        "ddl postgres progress smoke: ok "
+        "(DDL cursor progress verified, DML idle full copies=0)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -2702,26 +2702,43 @@ bool SnapshotTouchesSubscriptions(duckdb::Connection &conn, const std::string &c
 	return false;
 }
 
-std::vector<duckdb::Value> NextMatchingSnapshot(duckdb::Connection &conn, const std::string &cache_namespace,
-                                                const std::string &catalog_name, const ConsumerRow &consumer,
-                                                const std::vector<ConsumerSubscriptionRow> &subscriptions) {
+struct SnapshotMatchProbe {
+	duckdb::Value matching_snapshot;
+	int64_t scanned_through;
+
+	SnapshotMatchProbe(duckdb::Value matching_snapshot_p, int64_t scanned_through_p)
+	    : matching_snapshot(std::move(matching_snapshot_p)), scanned_through(scanned_through_p) {
+	}
+};
+
+SnapshotMatchProbe NextMatchingSnapshot(duckdb::Connection &conn, const std::string &cache_namespace,
+                                        const std::string &catalog_name, const ConsumerRow &consumer,
+                                        const std::vector<ConsumerSubscriptionRow> &subscriptions) {
 	if (OnlyDmlTableSubscriptions(subscriptions)) {
 		const auto current_snapshot = CurrentSnapshot(conn, catalog_name);
 		const auto snapshot = FirstDmlSubscribedSnapshot(conn, catalog_name, consumer.last_committed_snapshot,
 		                                                 current_snapshot, subscriptions);
 		if (snapshot != -1) {
-			return {duckdb::Value::BIGINT(snapshot),
-			        duckdb::Value::BIGINT(snapshot - consumer.last_committed_snapshot)};
+			return {duckdb::Value::BIGINT(snapshot), current_snapshot};
 		}
-		return {duckdb::Value(), duckdb::Value()};
+		return {duckdb::Value(), current_snapshot};
 	}
-	auto rows =
-	    conn.Query("SELECT snapshot_id, changes_made FROM " + MetadataTable(catalog_name, "ducklake_snapshot_changes") +
-	               " WHERE snapshot_id > " + std::to_string(consumer.last_committed_snapshot) +
-	               DmlTableSnapshotChangesFilter(subscriptions) + " ORDER BY snapshot_id ASC");
+	const auto current_snapshot = CurrentSnapshot(conn, catalog_name);
+	const auto range_sql = "SELECT snapshot_id, changes_made FROM " +
+	                       NativePostgresMetadataTable("ducklake_snapshot_changes") + " WHERE snapshot_id > " +
+	                       std::to_string(consumer.last_committed_snapshot) +
+	                       " AND snapshot_id <= " + std::to_string(current_snapshot) +
+	                       DmlTableSnapshotChangesFilter(subscriptions) + " ORDER BY snapshot_id ASC";
+	auto rows = MetadataBackendIsPostgres(conn, catalog_name)
+	                ? QueryPostgresMetadata(conn, catalog_name, range_sql)
+	                : conn.Query("SELECT snapshot_id, changes_made FROM " +
+	                             MetadataTable(catalog_name, "ducklake_snapshot_changes") + " WHERE snapshot_id > " +
+	                             std::to_string(consumer.last_committed_snapshot) +
+	                             " AND snapshot_id <= " + std::to_string(current_snapshot) +
+	                             DmlTableSnapshotChangesFilter(subscriptions) + " ORDER BY snapshot_id ASC");
 	ThrowIfQueryFailed(rows);
 	if (!rows) {
-		return {duckdb::Value(), duckdb::Value()};
+		return {duckdb::Value(), current_snapshot};
 	}
 	for (duckdb::idx_t row_idx = 0; row_idx < rows->RowCount(); ++row_idx) {
 		if (rows->GetValue(0, row_idx).IsNull()) {
@@ -2732,11 +2749,35 @@ std::vector<duckdb::Value> NextMatchingSnapshot(duckdb::Connection &conn, const 
 		const auto changes_made = changes_value.IsNull() ? std::string() : changes_value.ToString();
 		if (SnapshotTouchesSubscriptions(conn, cache_namespace, catalog_name, snapshot_id, changes_made,
 		                                 subscriptions)) {
-			return {duckdb::Value::BIGINT(snapshot_id),
-			        duckdb::Value::BIGINT(snapshot_id - consumer.last_committed_snapshot)};
+			return {duckdb::Value::BIGINT(snapshot_id), current_snapshot};
 		}
 	}
-	return {duckdb::Value(), duckdb::Value()};
+	return {duckdb::Value(), current_snapshot};
+}
+
+bool AdvanceDdlCursorPastInspectedSnapshots(duckdb::ClientContext &context, duckdb::Connection &conn,
+                                            const std::string &catalog_name, const ConsumerRow &probed_consumer,
+                                            int64_t inspected_through) {
+	if (probed_consumer.consumer_kind != "ddl" || inspected_through <= probed_consumer.last_committed_snapshot) {
+		return false;
+	}
+
+	const auto cached_token = CachedToken(context, catalog_name, probed_consumer.consumer_name);
+	ConsumerRow owned_consumer;
+	if (!TryUseFreshCachedLease(conn, catalog_name, probed_consumer.consumer_name, cached_token, owned_consumer)) {
+		const auto backend = CachedStateBackend(context, conn, catalog_name);
+		owned_consumer = AcquireLease(conn, catalog_name, probed_consumer.consumer_name, cached_token, backend);
+	}
+	CacheToken(context, catalog_name, probed_consumer.consumer_name, owned_consumer.owner_token.ToString());
+
+	// The subscription scan was performed from probed_consumer's cursor.
+	// A concurrent reset/commit changes that premise, so retry from the new
+	// cursor instead of advancing a range we did not inspect.
+	if (owned_consumer.last_committed_snapshot != probed_consumer.last_committed_snapshot) {
+		return false;
+	}
+	CommitConsumerSnapshotWithConnection(context, conn, catalog_name, probed_consumer.consumer_name, inspected_through);
+	return true;
 }
 
 duckdb::unique_ptr<duckdb::FunctionData> ListenWaitBind(duckdb::ClientContext &context,
@@ -2787,10 +2828,18 @@ WaitForNextSnapshotWithSubscriptions(duckdb::ClientContext &context, duckdb::Con
 			throw duckdb::InterruptException();
 		}
 		const auto row = LoadConsumerOrThrow(conn, catalog_name, consumer_name);
-		const auto next_matching =
-		    NextMatchingSnapshot(conn, ConnectionCachePrefix(context), catalog_name, row, subscriptions);
-		if (!next_matching.empty() && !next_matching[0].IsNull()) {
-			return next_matching;
+		const auto probe = NextMatchingSnapshot(conn, ConnectionCachePrefix(context), catalog_name, row, subscriptions);
+		if (!probe.matching_snapshot.IsNull()) {
+			const auto snapshot = probe.matching_snapshot.GetValue<int64_t>();
+			return {probe.matching_snapshot, duckdb::Value::BIGINT(snapshot - row.last_committed_snapshot)};
+		}
+		if (row.consumer_kind == "ddl" && probe.scanned_through > row.last_committed_snapshot) {
+			if (AdvanceDdlCursorPastInspectedSnapshots(context, conn, catalog_name, row, probe.scanned_through)) {
+				// Completing this empty window is observable progress. Return
+				// to the caller instead of holding the lease through another
+				// long wait without a heartbeat.
+				return {duckdb::Value()};
+			}
 		}
 		const auto now = std::chrono::steady_clock::now();
 		if (now >= deadline || clamped_timeout_ms == 0) {
@@ -3355,6 +3404,23 @@ std::vector<duckdb::Value> ReadWindowWithConnection(duckdb::ClientContext &conte
 	const bool is_dml = consumer_kind == "dml";
 
 	if (is_dml) {
+		// DuckDB's Postgres scanner cannot push the aggregate in
+		// ResolveDmlWindowIndexed into the remote query. Avoid copying the
+		// complete snapshot metadata history when this consumer is already at
+		// the catalogue head—the steady-state path for non-blocking relays.
+		if (MetadataBackendIsPostgres(conn, data.catalog_name)) {
+			const auto current_snapshot = CurrentSnapshot(conn, data.catalog_name);
+			if (last_snapshot == current_snapshot) {
+				CacheDmlSafeCommitRange(context, data.catalog_name, data.consumer_name, last_snapshot, last_snapshot);
+				return {duckdb::Value::BIGINT(last_snapshot + 1),
+				        duckdb::Value::BIGINT(last_snapshot),
+				        duckdb::Value::BOOLEAN(false),
+				        duckdb::Value::BIGINT(row.last_committed_schema_version),
+				        duckdb::Value::BOOLEAN(false),
+				        duckdb::Value::BOOLEAN(false),
+				        duckdb::Value()};
+			}
+		}
 		const auto subscriptions = LoadDmlConsumerSubscriptions(conn, data.catalog_name, data.consumer_name);
 		const auto resolved =
 		    ResolveDmlWindowIndexed(conn, data.catalog_name, last_snapshot, data.max_snapshots, subscriptions);

--- a/src/ddl.cpp
+++ b/src/ddl.cpp
@@ -1268,9 +1268,13 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcDdlInit(duckdb::ClientCo
 	auto result = duckdb::make_uniq<RowScanState>();
 	auto &data = input.bind_data->Cast<CdcDdlData>();
 	auto max_snapshots = data.max_snapshots;
-	if (data.listen && !data.explicit_window) {
+	if (!data.explicit_window) {
+		// Both stateful entry points must probe for subscription-relevant DDL.
+		// A non-blocking read uses a zero timeout; the probe still durably
+		// advances a DDL cursor across an inspected DML-only window.
+		const auto timeout_ms = data.listen ? data.timeout_ms : 0;
 		auto ready =
-		    WaitForConsumerSnapshot(context, data.catalog_name, data.consumer_name, data.timeout_ms, data.poll_min_ms);
+		    WaitForConsumerSnapshot(context, data.catalog_name, data.consumer_name, timeout_ms, data.poll_min_ms);
 		if (ready.empty() || ready[0].IsNull()) {
 			return std::move(result);
 		}

--- a/src/ducklake_metadata.cpp
+++ b/src/ducklake_metadata.cpp
@@ -357,6 +357,11 @@ int64_t ResolveSchemaVersion(duckdb::Connection &conn, const std::string &catalo
 }
 
 int64_t CurrentSnapshot(duckdb::Connection &conn, const std::string &catalog_name) {
+	if (MetadataBackendIsPostgres(conn, catalog_name)) {
+		auto result = QueryPostgresMetadata(
+		    conn, catalog_name, "SELECT max(snapshot_id) AS current_snapshot FROM public.ducklake_snapshot");
+		return SingleInt64(*result, "current snapshot");
+	}
 	auto result = conn.Query("SELECT max(snapshot_id) FROM " + MetadataTable(catalog_name, "ducklake_snapshot"));
 	return SingleInt64(*result, "current snapshot");
 }
@@ -590,8 +595,24 @@ std::string SnapshotNotifyChannel(const std::string &catalog_name) {
 }
 
 bool MetadataBackendIsPostgres(duckdb::Connection &conn, const std::string &catalog_name) {
-	auto result = conn.Query("SELECT type FROM duckdb_databases() WHERE database_name = " +
-	                         QuoteLiteral("__ducklake_metadata_" + catalog_name) + " LIMIT 1");
+	// DuckLake keeps its metadata attachment private, so it is not present in
+	// duckdb_databases(). The public DuckLake catalog path records the metadata
+	// backend as `postgres:<dsn>` and is the authoritative discriminator.
+	auto result = conn.Query(
+	    "SELECT type, path FROM duckdb_databases() WHERE database_name = " + QuoteLiteral(catalog_name) + " LIMIT 1");
+	if (result && !result->HasError() && result->RowCount() > 0 && !result->GetValue(0, 0).IsNull() &&
+	    !result->GetValue(1, 0).IsNull()) {
+		const auto type = duckdb::StringUtil::Lower(result->GetValue(0, 0).ToString());
+		const auto path = duckdb::StringUtil::Lower(result->GetValue(1, 0).ToString());
+		if (type == "ducklake" && StartsWith(path, "postgres:")) {
+			return true;
+		}
+	}
+
+	// Keep supporting an explicitly visible metadata attachment for direct
+	// extension tests and non-DuckLake callers.
+	result = conn.Query("SELECT type FROM duckdb_databases() WHERE database_name = " +
+	                    QuoteLiteral("__ducklake_metadata_" + catalog_name) + " LIMIT 1");
 	if (!result || result->HasError() || result->RowCount() == 0 || result->GetValue(0, 0).IsNull()) {
 		return false;
 	}
@@ -600,12 +621,31 @@ bool MetadataBackendIsPostgres(duckdb::Connection &conn, const std::string &cata
 }
 
 std::string PostgresMetadataDsn(duckdb::Connection &conn, const std::string &catalog_name) {
-	auto result = conn.Query("SELECT path FROM duckdb_databases() WHERE database_name = " +
-	                         QuoteLiteral("__ducklake_metadata_" + catalog_name) + " LIMIT 1");
+	auto result = conn.Query(
+	    "SELECT type, path FROM duckdb_databases() WHERE database_name = " + QuoteLiteral(catalog_name) + " LIMIT 1");
+	if (result && !result->HasError() && result->RowCount() > 0 && !result->GetValue(0, 0).IsNull() &&
+	    !result->GetValue(1, 0).IsNull()) {
+		const auto type = duckdb::StringUtil::Lower(result->GetValue(0, 0).ToString());
+		const auto path = result->GetValue(1, 0).ToString();
+		if (type == "ducklake" && StartsWith(duckdb::StringUtil::Lower(path), "postgres:")) {
+			return path.substr(std::string("postgres:").size());
+		}
+	}
+
+	result = conn.Query("SELECT path FROM duckdb_databases() WHERE database_name = " +
+	                    QuoteLiteral("__ducklake_metadata_" + catalog_name) + " LIMIT 1");
 	if (!result || result->HasError() || result->RowCount() == 0 || result->GetValue(0, 0).IsNull()) {
 		return "";
 	}
 	return result->GetValue(0, 0).ToString();
+}
+
+duckdb::unique_ptr<duckdb::MaterializedQueryResult>
+QueryPostgresMetadata(duckdb::Connection &conn, const std::string &catalog_name, const std::string &sql) {
+	auto result = conn.Query("SELECT * FROM postgres_query(" + QuoteLiteral("__ducklake_metadata_" + catalog_name) +
+	                         ", " + QuoteLiteral(sql) + ")");
+	ThrowIfQueryFailed(result);
+	return result;
 }
 
 void PostgresExecuteBestEffort(duckdb::Connection &conn, const std::string &catalog_name, const std::string &sql) {

--- a/src/include/ducklake_metadata.hpp
+++ b/src/include/ducklake_metadata.hpp
@@ -94,6 +94,8 @@ std::string StateTable(duckdb::Connection &conn, const std::string &catalog_name
 std::string SnapshotNotifyChannel(const std::string &catalog_name);
 bool MetadataBackendIsPostgres(duckdb::Connection &conn, const std::string &catalog_name);
 std::string PostgresMetadataDsn(duckdb::Connection &conn, const std::string &catalog_name);
+duckdb::unique_ptr<duckdb::MaterializedQueryResult>
+QueryPostgresMetadata(duckdb::Connection &conn, const std::string &catalog_name, const std::string &sql);
 
 //===--------------------------------------------------------------------===//
 // Snapshot fact lookups

--- a/test/consumer_lifecycle.test
+++ b/test/consumer_lifecycle.test
@@ -96,3 +96,218 @@ FROM cdc_list_consumers('lake')
 WHERE consumer_name = 'items_sink';
 ----
 0
+
+# ---------------------------------------------------------------------------
+# DDL listen progress: inspected DML-only snapshots advance the durable cursor
+# without weakening caller-committed delivery for real DDL.
+# ---------------------------------------------------------------------------
+
+statement ok
+SELECT * FROM cdc_ddl_consumer_create(
+  'lake',
+  'ddl_progress',
+  start_at := 'now'
+);
+
+statement ok
+INSERT INTO lake.items VALUES (3, 'three');
+
+statement ok
+INSERT INTO lake.items VALUES (4, 'four');
+
+statement ok
+INSERT INTO lake.items VALUES (5, 'five');
+
+query I
+SELECT count(*)
+FROM cdc_ddl_changes_listen(
+  'lake',
+  'ddl_progress',
+  timeout_ms := 0,
+  max_snapshots := 1000
+);
+----
+0
+
+query I
+SELECT last_committed_snapshot = (
+  SELECT max(snapshot_id)
+  FROM __ducklake_metadata_lake.ducklake_snapshot
+)
+FROM cdc_list_consumers('lake')
+WHERE consumer_name = 'ddl_progress';
+----
+true
+
+statement ok
+ALTER TABLE lake.items ADD COLUMN tag VARCHAR;
+
+query III
+SELECT count(*),
+       count(*) FILTER (
+         WHERE event_kind = 'altered'
+           AND object_kind = 'table'
+           AND object_name = 'items'
+       ),
+       min(start_snapshot) = max(end_snapshot)
+FROM cdc_ddl_changes_listen(
+  'lake',
+  'ddl_progress',
+  timeout_ms := 0,
+  max_snapshots := 1000
+);
+----
+1	1	true
+
+# Non-empty DDL remains caller-committed.
+query I
+SELECT last_committed_snapshot < (
+  SELECT max(snapshot_id)
+  FROM __ducklake_metadata_lake.ducklake_snapshot
+)
+FROM cdc_list_consumers('lake')
+WHERE consumer_name = 'ddl_progress';
+----
+true
+
+statement ok
+SET VARIABLE ddl_snapshot = (
+  SELECT max(snapshot_id)
+  FROM __ducklake_metadata_lake.ducklake_snapshot
+);
+
+statement ok
+SELECT * FROM cdc_commit(
+  'lake',
+  'ddl_progress',
+  getvariable('ddl_snapshot')
+);
+
+query I
+SELECT count(*)
+FROM cdc_ddl_changes_listen(
+  'lake',
+  'ddl_progress',
+  timeout_ms := 0,
+  max_snapshots := 1000
+);
+----
+0
+
+# A scoped DDL consumer applies the same rule to DDL on unsubscribed objects:
+# advance the irrelevant snapshot, then deliver the first matching DDL.
+statement ok
+CREATE SCHEMA lake.aux;
+
+statement ok
+SELECT * FROM cdc_ddl_consumer_create(
+  'lake',
+  'aux_ddl_progress',
+  schemas := ['aux'],
+  start_at := 'now'
+);
+
+statement ok
+CREATE TABLE lake.main_only(id INTEGER);
+
+query I
+SELECT count(*)
+FROM cdc_ddl_changes_listen(
+  'lake',
+  'aux_ddl_progress',
+  timeout_ms := 0,
+  max_snapshots := 1000
+);
+----
+0
+
+query I
+SELECT last_committed_snapshot = (
+  SELECT max(snapshot_id)
+  FROM __ducklake_metadata_lake.ducklake_snapshot
+)
+FROM cdc_list_consumers('lake')
+WHERE consumer_name = 'aux_ddl_progress';
+----
+true
+
+statement ok
+CREATE TABLE lake.aux.watched(id INTEGER);
+
+query II
+SELECT count(*),
+       count(*) FILTER (
+         WHERE event_kind = 'created'
+           AND object_kind = 'table'
+           AND schema_name = 'aux'
+           AND object_name = 'watched'
+       )
+FROM cdc_ddl_changes_listen(
+  'lake',
+  'aux_ddl_progress',
+  timeout_ms := 0,
+  max_snapshots := 1000
+);
+----
+1	1
+
+# Non-blocking reads use the same durable empty-window progress rule. This is
+# the path used by Atlas's catalogue relay.
+statement ok
+SELECT * FROM cdc_ddl_consumer_create(
+  'lake',
+  'ddl_read_progress',
+  start_at := 'now'
+);
+
+statement ok
+INSERT INTO lake.items VALUES (6, 'six', NULL);
+
+query I
+SELECT count(*)
+FROM cdc_ddl_changes_read(
+  'lake',
+  'ddl_read_progress',
+  max_snapshots := 1000
+);
+----
+0
+
+query I
+SELECT last_committed_snapshot = (
+  SELECT max(snapshot_id)
+  FROM __ducklake_metadata_lake.ducklake_snapshot
+)
+FROM cdc_list_consumers('lake')
+WHERE consumer_name = 'ddl_read_progress';
+----
+true
+
+statement ok
+ALTER TABLE lake.items ADD COLUMN score INTEGER;
+
+query II
+SELECT count(*),
+       count(*) FILTER (
+         WHERE event_kind = 'altered'
+           AND object_kind = 'table'
+           AND object_name = 'items'
+       )
+FROM cdc_ddl_changes_read(
+  'lake',
+  'ddl_read_progress',
+  max_snapshots := 1000
+);
+----
+1	1
+
+# A delivered DDL batch remains caller-committed for read just as for listen.
+query I
+SELECT last_committed_snapshot < (
+  SELECT max(snapshot_id)
+  FROM __ducklake_metadata_lake.ducklake_snapshot
+)
+FROM cdc_list_consumers('lake')
+WHERE consumer_name = 'ddl_read_progress';
+----
+true

--- a/test/version_and_load.test
+++ b/test/version_and_load.test
@@ -15,7 +15,7 @@ require ducklake_cdc
 query I
 SELECT cdc_version();
 ----
-ducklake_cdc 0.6.0
+ducklake_cdc 0.6.1
 
 query I
 SELECT length(cdc_build_revision()) > 0;


### PR DESCRIPTION
## Summary

- detect PostgreSQL-backed DuckLake catalogues through the public catalogue path
- advance DDL consumers across inspected non-DDL snapshots without hiding real DDL from caller acknowledgement
- replace caught-up DML history scans with a bounded PostgreSQL head probe
- add SQL lifecycle coverage and a PostgreSQL end-to-end regression/performance smoke test

## Why

Atlas uses one catalogue-wide DDL relay and one catalogue-wide DML-tick relay. On PostgreSQL metadata catalogues, idle reads could repeatedly copy or scan snapshot history, while DDL consumers did not durably advance across DML-only snapshots. That caused increasing relay cost and stalled downstream materialization ticks.

## Validation

- `make test_local_full` — 348 assertions across 11 suites
- pinned `make format-check`
- Ruff check for the new smoke probe
- PostgreSQL progress smoke — DDL cursor progress verified; caught-up DML full-history copies: 0

## Release

Prepared as `v0.6.1`; release automation will publish binaries and open the DuckDB community-extension update after this lands on `main`.
