### PR TITLE
Bump version to 0.6.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(TARGET_NAME ducklake_cdc)
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
-project(${TARGET_NAME} VERSION 0.6.1)
+project(${TARGET_NAME} VERSION 0.6.2)
 
 set(CMAKE_CXX_STANDARD "17" CACHE STRING "C++ standard to enforce")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/docs/api.md
+++ b/docs/api.md
@@ -109,7 +109,7 @@ SELECT cdc_version();
 Returns the loaded extension version as a scalar `VARCHAR`.
 
 The value is the stable semantic release version, for example
-`ducklake_cdc 0.6.1`. Use `cdc_build_revision()` when an exact source/build
+`ducklake_cdc 0.6.2`. Use `cdc_build_revision()` when an exact source/build
 identity is required.
 
 Use it in support tickets, CI logs, benchmark output, and migration checks.

--- a/test/version_and_load.test
+++ b/test/version_and_load.test
@@ -15,7 +15,7 @@ require ducklake_cdc
 query I
 SELECT cdc_version();
 ----
-ducklake_cdc 0.6.1
+ducklake_cdc 0.6.2
 
 query I
 SELECT length(cdc_build_revision()) > 0;


### PR DESCRIPTION
## Summary

- bump the extension semantic version to 0.6.2
- update the version smoke expectation and API example

## Why

`v0.6.1` was already released from the previous main SHA. The per-DuckLake CDC state isolation release therefore needs the next patch version.

## Validation

- release build
- `test/version_and_load.test`
- pre-commit format checks
- full release dry-run matrix and sanitizer gates already passed for the implementation SHA