### PR TITLE
Fast-forward release/0.6 to v0.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
         run: |
           docker compose -f e2e/docker-compose.yml up -d --wait
           trap 'docker compose -f e2e/docker-compose.yml down -v' EXIT
+          uv run --project e2e --locked python e2e/smoke/ddl_postgres_listener_progress_smoke.py
           uv run --project e2e --locked python e2e/ci_demo_assertions.py
 
   upstream-contract-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
         run: |
           docker compose -f e2e/docker-compose.yml up -d --wait
           trap 'docker compose -f e2e/docker-compose.yml down -v' EXIT
+          uv run --project e2e --locked python e2e/smoke/postgres_state_isolation_smoke.py
           uv run --project e2e --locked python e2e/smoke/ddl_postgres_listener_progress_smoke.py
           uv run --project e2e --locked python e2e/ci_demo_assertions.py
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(TARGET_NAME ducklake_cdc)
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
-project(${TARGET_NAME} VERSION 0.6.0)
+project(${TARGET_NAME} VERSION 0.6.1)
 
 set(CMAKE_CXX_STANDARD "17" CACHE STRING "C++ standard to enforce")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(TARGET_NAME ducklake_cdc)
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
-project(${TARGET_NAME} VERSION 0.6.1)
+project(${TARGET_NAME} VERSION 0.6.2)
 
 set(CMAKE_CXX_STANDARD "17" CACHE STRING "C++ standard to enforce")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ end-to-end latency, you probably want something built for that job.
 
 ## Use It From SQL
 
+When multiple DuckLakes keep metadata in different schemas of the same
+PostgreSQL database, configure a lake-owned CDC schema immediately after
+`ATTACH` and before the first stateful `cdc_*` call:
+
+```sql
+CALL cdc_configure(
+  'lake',
+  state_schema := 'ducklake_cdc_8f6d...',
+  metadata_schema := 'ducklake_8f6d...'
+);
+```
+
+The mapping is connection-process configuration and must be repeated after a
+restart. Existing single-lake installations that omit it continue to use
+`__ducklake_cdc` and PostgreSQL's `public` metadata schema. Selecting a new
+state schema does not migrate consumers, leases, cursors, or audit rows.
+
 Create a durable DML consumer and read row changes:
 
 ```sql

--- a/docs/api.md
+++ b/docs/api.md
@@ -74,7 +74,7 @@ SELECT cdc_version();
 Returns the loaded extension version as a scalar `VARCHAR`.
 
 The value is the stable semantic release version, for example
-`ducklake_cdc 0.6.0`. Use `cdc_build_revision()` when an exact source/build
+`ducklake_cdc 0.6.1`. Use `cdc_build_revision()` when an exact source/build
 identity is required.
 
 Use it in support tickets, CI logs, benchmark output, and migration checks.
@@ -572,6 +572,12 @@ FROM cdc_ddl_changes_listen(
 Waits until DDL changes matching the consumer are available or the deadline is
 reached, then returns parsed DDL changes.
 
+When catalog activity contains no DDL matching this consumer, both stateful
+read and listen durably advance the cursor through the inspected snapshots and
+may return an empty result. This is internal no-op acknowledgement, not
+`auto_commit`: a non-empty DDL result remains caller-committed unless
+`auto_commit := TRUE`.
+
 `poll_min_ms` controls the initial polling interval for backends without an
 event wakeup path (or when the wakeup path is unavailable). The interval
 backs off exponentially after each empty probe. PostgreSQL catalogs use the
@@ -799,6 +805,12 @@ FROM cdc_dml_ticks_read(
 ```
 
 Reads DML-relevant snapshot ticks for the consumer without waiting.
+
+For PostgreSQL-backed catalogues, a consumer already at catalogue head is
+resolved with a native bounded head probe. The steady-state empty read does
+not copy the full DuckLake snapshot metadata history through DuckDB's
+Postgres scanner. This is an empty-read optimization only; the next non-empty
+tick remains caller-committed unless `auto_commit := TRUE`.
 
 Returns:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -109,7 +109,7 @@ SELECT cdc_version();
 Returns the loaded extension version as a scalar `VARCHAR`.
 
 The value is the stable semantic release version, for example
-`ducklake_cdc 0.6.1`. Use `cdc_build_revision()` when an exact source/build
+`ducklake_cdc 0.6.2`. Use `cdc_build_revision()` when an exact source/build
 identity is required.
 
 Use it in support tickets, CI logs, benchmark output, and migration checks.

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,8 @@ release.
 ## Conventions
 
 - Every public function is registered as a DuckDB table function and is called
-  from a `FROM` clause, except `cdc_version()`, which is scalar.
+  from a `FROM` clause. `cdc_configure` may also be invoked with `CALL`, and
+  `cdc_version()` is scalar.
 - All functions take an explicit `catalog` argument: the attached DuckLake
   catalog name, for example `'lake'` after `ATTACH ... AS lake`.
 - Stateful functions operate on a named consumer cursor. A consumer owns a
@@ -26,6 +27,7 @@ release.
 ## Index
 
 - General:
+  [`cdc_configure`](#cdc_configure),
   [`cdc_version`](#cdc_version),
   [`cdc_doctor`](#cdc_doctor),
   [`cdc_list_consumers`](#cdc_list_consumers),
@@ -64,6 +66,39 @@ release.
 ---
 
 ## General
+
+### `cdc_configure`
+
+```sql
+CALL cdc_configure(
+  catalog,
+  state_schema := 'ducklake_cdc_<lake-id>',
+  metadata_schema := 'ducklake_<lake-id>'
+);
+```
+
+Configures the durable CDC and DuckLake metadata schemas for one attachment.
+Use it after `ATTACH` and before the first stateful `cdc_*` call when multiple
+DuckLakes share one PostgreSQL database. Repeating the same mapping is
+idempotent; conflicting mappings are rejected.
+
+The mapping is scoped to the resolved attachment identity, not merely its SQL
+alias, and is not persisted by the extension. A runner must repeat the call
+after each process restart. Schema names are PostgreSQL identifiers and may be
+at most 63 bytes.
+
+If this function is omitted, the backward-compatible defaults are
+`state_schema = '__ducklake_cdc'` and `metadata_schema = 'public'`. Changing
+the configured state schema deliberately does not migrate existing consumer
+cursors, leases, subscriptions, or audit history.
+
+Returns:
+
+```text
+catalog_name VARCHAR
+state_schema VARCHAR
+metadata_schema VARCHAR
+```
 
 ### `cdc_version`
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -170,7 +170,7 @@ Release. Asset names include the extension version, DuckDB version, and DuckDB
 platform, for example:
 
 ```text
-ducklake_cdc-v0.6.0-duckdb-v1.5.4-linux_arm64.duckdb_extension
+ducklake_cdc-v0.6.1-duckdb-v1.5.4-linux_arm64.duckdb_extension
 ```
 
 `SHA256SUMS` in the same release pins their contents. These maintainer release

--- a/e2e/smoke/README.md
+++ b/e2e/smoke/README.md
@@ -47,3 +47,17 @@ uv run python e2e/smoke/enumerate_changes_map.py --backends duckdb sqlite postgr
 
 The script sets `DATA_INLINING_ROW_LIMIT = 10` explicitly (DuckLake's spec default)
 so inlined-data boundary checks stay deterministic across local runs and CI.
+
+## PostgreSQL consumer progress
+
+`ddl_postgres_listener_progress_smoke.py` guards the catalogue-relay workload:
+caught-up DDL read and listen calls must durably skip a new DML-only snapshot
+without sequentially rereading the complete Postgres snapshot metadata
+history, and must still deliver the next real DDL event. It also verifies that
+a caught-up non-blocking DML tick read uses a bounded head probe instead of a
+complete snapshot-table copy, while leaving the next real tick caller-committed.
+
+```bash
+docker compose -f e2e/docker-compose.yml up -d --wait postgres
+uv run --project e2e python e2e/smoke/ddl_postgres_listener_progress_smoke.py
+```

--- a/e2e/smoke/ddl_postgres_listener_progress_smoke.py
+++ b/e2e/smoke/ddl_postgres_listener_progress_smoke.py
@@ -1,0 +1,202 @@
+"""Postgres regression for DDL listener progress and bounded metadata reads.
+
+Requires the e2e Postgres service:
+
+    docker compose -f e2e/docker-compose.yml up -d --wait postgres
+    uv run --project e2e python e2e/smoke/ddl_postgres_listener_progress_smoke.py
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import shutil
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeVar
+
+import duckdb
+import psycopg
+from _harness_env import CDC_EXTENSION
+
+PG_DSN = "postgresql://ducklake:ducklake@localhost:5436/ducklake"
+HISTORY_SNAPSHOTS = 300
+T = TypeVar("T")
+
+
+def reset_catalog() -> None:
+    with psycopg.connect(PG_DSN) as pg:
+        pg.execute('DROP SCHEMA IF EXISTS "__ducklake_cdc" CASCADE')
+        pg.execute("DROP SCHEMA IF EXISTS public CASCADE")
+        pg.execute("CREATE SCHEMA public")
+        pg.commit()
+
+
+def capture_postgres_queries(con: duckdb.DuckDBPyConnection, action: Callable[[], T]) -> tuple[T, str]:
+    """Capture SQL emitted by DuckDB's Postgres scanner for one action."""
+
+    con.execute("SET pg_debug_show_queries = true")
+    with tempfile.TemporaryFile(mode="w+b") as captured:
+        stdout = os.dup(1)
+        stderr = os.dup(2)
+        os.dup2(captured.fileno(), 1)
+        os.dup2(captured.fileno(), 2)
+        try:
+            result = action()
+            ctypes.CDLL(None).fflush(None)
+        finally:
+            os.dup2(stdout, 1)
+            os.dup2(stderr, 2)
+            os.close(stdout)
+            os.close(stderr)
+            con.execute("SET pg_debug_show_queries = false")
+        captured.seek(0)
+        queries = captured.read().decode(errors="replace")
+    return result, queries
+
+
+def full_snapshot_copies(queries: str) -> list[str]:
+    copies = []
+    for raw_statement in queries.split("\n\n"):
+        statement = raw_statement.strip()
+        if not statement.startswith("COPY (SELECT") or not (
+            '"ducklake_snapshot"' in statement
+            or '"ducklake_snapshot_changes"' in statement
+        ):
+            continue
+        _, separator, predicate = statement.upper().partition(" WHERE ")
+        if not separator or "SNAPSHOT_ID" not in predicate:
+            copies.append(statement)
+    return copies
+
+
+def durable_cursor(consumer_name: str) -> tuple[int, int]:
+    with psycopg.connect(PG_DSN) as pg:
+        row = pg.execute(
+            """
+            SELECT c.last_committed_snapshot,
+                   (SELECT max(snapshot_id) FROM public.ducklake_snapshot)
+            FROM __ducklake_cdc.__ducklake_cdc_consumers c
+            WHERE c.consumer_name = %s
+            """,
+            (consumer_name,),
+        ).fetchone()
+        assert row is not None
+        return int(row[0]), int(row[1])
+
+
+def main() -> None:
+    reset_catalog()
+    with tempfile.TemporaryDirectory(prefix="ducklake_cdc_ddl_pg_") as tmp:
+        data_path = Path(tmp) / "data"
+        shutil.rmtree(data_path, ignore_errors=True)
+        data_path.mkdir()
+
+        con = duckdb.connect(config={"allow_unsigned_extensions": True, "threads": 1})
+        try:
+            con.execute("INSTALL postgres; LOAD postgres; INSTALL ducklake; LOAD ducklake;")
+            con.load_extension(str(CDC_EXTENSION))
+            con.execute(f"ATTACH 'ducklake:postgres:{PG_DSN}' AS lake (DATA_PATH '{data_path.as_posix()}')")
+            con.execute("SELECT cdc_version()")
+            con.execute("SELECT count(*) FROM cdc_list_consumers('lake')")
+            con.execute("CREATE TABLE lake.items(id BIGINT)")
+            con.execute("SELECT * FROM cdc_ddl_consumer_create('lake', 'ddl_scan', start_at := 'now')")
+
+            for value in range(HISTORY_SNAPSHOTS):
+                con.execute("INSERT INTO lake.items VALUES (?)", [value])
+
+            # Drain the initial history first. The transport assertion below
+            # measures the steady-state case that regressed in Atlas: one new
+            # DML snapshot waking a caught-up DDL listener.
+            rows = con.execute("SELECT * FROM cdc_ddl_changes_listen('lake', 'ddl_scan', timeout_ms := 0)").fetchall()
+            assert rows == []
+            assert durable_cursor("ddl_scan")[0] == durable_cursor("ddl_scan")[1]
+
+            con.execute("INSERT INTO lake.items VALUES (?)", [HISTORY_SNAPSHOTS])
+            rows = con.execute(
+                "SELECT * FROM cdc_ddl_changes_listen('lake', 'ddl_scan', timeout_ms := 0)"
+            ).fetchall()
+            assert rows == []
+
+            cursor, head = durable_cursor("ddl_scan")
+            assert cursor == head, (cursor, head)
+
+            # Advancing empty DML windows must not consume the next real DDL.
+            con.execute("ALTER TABLE lake.items ADD COLUMN tag VARCHAR")
+            ddl_rows = con.execute(
+                "SELECT event_kind, object_kind, object_name, end_snapshot FROM cdc_ddl_changes_listen('lake', 'ddl_scan', timeout_ms := 0)"
+            ).fetchall()
+            assert len(ddl_rows) == 1, ddl_rows
+            assert ddl_rows[0][:3] == ("altered", "table", "items"), ddl_rows
+            assert durable_cursor("ddl_scan")[0] < durable_cursor("ddl_scan")[1]
+            con.execute(
+                "SELECT * FROM cdc_commit('lake', 'ddl_scan', ?)",
+                [ddl_rows[0][3]],
+            )
+
+            # Atlas uses the non-blocking read entry point. It must have the
+            # same bounded metadata access and empty-window progress semantics.
+            con.execute("SELECT * FROM cdc_ddl_consumer_create('lake', 'ddl_read_scan', start_at := 'now')")
+            con.execute("INSERT INTO lake.items VALUES (?, NULL)", [HISTORY_SNAPSHOTS + 1])
+            rows = con.execute("SELECT * FROM cdc_ddl_changes_read('lake', 'ddl_read_scan')").fetchall()
+            assert rows == []
+            read_cursor, read_head = durable_cursor("ddl_read_scan")
+            assert read_cursor == read_head, (read_cursor, read_head)
+
+            con.execute("ALTER TABLE lake.items ADD COLUMN score INTEGER")
+            read_ddl_rows = con.execute(
+                "SELECT event_kind, object_kind, object_name, end_snapshot "
+                "FROM cdc_ddl_changes_read('lake', 'ddl_read_scan')"
+            ).fetchall()
+            assert len(read_ddl_rows) == 1, read_ddl_rows
+            assert read_ddl_rows[0][:3] == ("altered", "table", "items"), read_ddl_rows
+            assert durable_cursor("ddl_read_scan")[0] < durable_cursor("ddl_read_scan")[1]
+            con.execute(
+                "SELECT * FROM cdc_commit('lake', 'ddl_read_scan', ?)",
+                [read_ddl_rows[0][3]],
+            )
+
+            # Atlas's global DML relay also polls with non-blocking read. At
+            # the catalogue head that probe must not fall through to a full
+            # DuckLake metadata window scan.
+            con.execute("SELECT * FROM cdc_dml_consumer_create('lake', 'dml_read_scan', start_at := 'now')")
+            dml_rows: list[tuple] = []
+
+            def poll_dml_head() -> None:
+                nonlocal dml_rows
+                for _ in range(10):
+                    dml_rows = con.execute(
+                        "SELECT * FROM cdc_dml_ticks_read('lake', 'dml_read_scan')"
+                    ).fetchall()
+
+            _, dml_read_queries = capture_postgres_queries(con, poll_dml_head)
+            assert dml_rows == []
+            dml_cursor, dml_head = durable_cursor("dml_read_scan")
+            assert dml_cursor == dml_head, (dml_cursor, dml_head)
+            dml_full_copies = full_snapshot_copies(dml_read_queries)
+            assert dml_full_copies == [], dml_full_copies
+
+            # The probe is only an idle fast path. The next matching DML tick
+            # remains caller-committed.
+            con.execute("INSERT INTO lake.items VALUES (?, NULL, NULL)", [HISTORY_SNAPSHOTS + 2])
+            dml_rows = con.execute(
+                "SELECT table_ids, end_snapshot FROM cdc_dml_ticks_read('lake', 'dml_read_scan')"
+            ).fetchall()
+            assert len(dml_rows) == 1, dml_rows
+            assert durable_cursor("dml_read_scan")[0] < durable_cursor("dml_read_scan")[1]
+            con.execute(
+                "SELECT * FROM cdc_commit('lake', 'dml_read_scan', ?)",
+                [dml_rows[0][1]],
+            )
+        finally:
+            con.close()
+
+    print(
+        "ddl postgres progress smoke: ok "
+        "(DDL cursor progress verified, DML idle full copies=0)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/smoke/postgres_state_isolation_smoke.py
+++ b/e2e/smoke/postgres_state_isolation_smoke.py
@@ -1,0 +1,185 @@
+"""Per-DuckLake CDC state isolation regression for a shared PostgreSQL database.
+
+Requires the e2e PostgreSQL service and a release build:
+
+    docker compose -f e2e/docker-compose.yml up -d --wait postgres
+    uv run --project e2e python e2e/smoke/postgres_state_isolation_smoke.py
+"""
+
+from __future__ import annotations
+
+import tempfile
+from concurrent.futures import ProcessPoolExecutor
+from multiprocessing import get_context
+from pathlib import Path
+
+import duckdb
+import psycopg
+from _harness_env import CDC_EXTENSION
+
+PG_DSN = "postgresql://ducklake:ducklake@localhost:5436/ducklake"
+LAKES = {
+    "alpha": ("ducklake_alpha", "ducklake_cdc_alpha"),
+    "beta": ("ducklake_beta", "ducklake_cdc_beta"),
+}
+
+
+def reset_schemas() -> None:
+    with psycopg.connect(PG_DSN) as pg:
+        for metadata_schema, state_schema in LAKES.values():
+            pg.execute(f'DROP SCHEMA IF EXISTS "{state_schema}" CASCADE')
+            pg.execute(f'DROP SCHEMA IF EXISTS "{metadata_schema}" CASCADE')
+            pg.execute(f'CREATE SCHEMA "{metadata_schema}"')
+        pg.commit()
+
+
+def scalar(con: duckdb.DuckDBPyConnection, sql: str, params: list[object] | None = None) -> object:
+    row = con.execute(sql, params or []).fetchone()
+    assert row is not None
+    return row[0]
+
+
+def bootstrap_worker(metadata_schema: str, state_schema: str, data_path: str) -> None:
+    """Bootstrap one lake in an independent runner process using the common alias `lake`."""
+
+    con = duckdb.connect(config={"allow_unsigned_extensions": True, "threads": 1})
+    try:
+        con.execute("INSTALL postgres; LOAD postgres; INSTALL ducklake; LOAD ducklake;")
+        con.load_extension(str(CDC_EXTENSION))
+        con.execute(f"ATTACH 'ducklake:postgres:{PG_DSN}' AS lake (METADATA_SCHEMA '{metadata_schema}', DATA_PATH '{data_path}')")
+        con.execute(f"CALL cdc_configure('lake', state_schema := '{state_schema}', metadata_schema := '{metadata_schema}')")
+        assert con.execute("SELECT count(*) FROM cdc_list_consumers('lake')").fetchone() == (0,)
+    finally:
+        con.close()
+
+
+def main() -> None:
+    reset_schemas()
+    with tempfile.TemporaryDirectory(prefix="ducklake_cdc_isolation_") as tmp:
+        con = duckdb.connect(config={"allow_unsigned_extensions": True, "threads": 1})
+        try:
+            con.execute("INSTALL postgres; LOAD postgres; INSTALL ducklake; LOAD ducklake;")
+            con.load_extension(str(CDC_EXTENSION))
+            for alias, (metadata_schema, state_schema) in LAKES.items():
+                data_path = (Path(tmp) / alias).as_posix()
+                con.execute(f"ATTACH 'ducklake:postgres:{PG_DSN}' AS {alias} (METADATA_SCHEMA '{metadata_schema}', DATA_PATH '{data_path}')")
+                configured = con.execute(f"CALL cdc_configure('{alias}', state_schema := '{state_schema}', metadata_schema := '{metadata_schema}')").fetchone()
+                assert configured == (alias, state_schema, metadata_schema), configured
+                con.execute(f"CREATE TABLE {alias}.items(id BIGINT)")
+
+            # First bootstrap happens concurrently in separate runner
+            # processes. Both intentionally attach their lake as `lake`.
+            with ProcessPoolExecutor(max_workers=3, mp_context=get_context("spawn")) as executor:
+                futures = [
+                    executor.submit(
+                        bootstrap_worker,
+                        metadata_schema,
+                        state_schema,
+                        (Path(tmp) / alias).as_posix(),
+                    )
+                    for alias, (metadata_schema, state_schema) in LAKES.items()
+                ]
+                # A second Alpha runner races the exact same first bootstrap;
+                # backend DDL and trigger installation must remain idempotent.
+                futures.append(
+                    executor.submit(
+                        bootstrap_worker,
+                        LAKES["alpha"][0],
+                        LAKES["alpha"][1],
+                        (Path(tmp) / "alpha").as_posix(),
+                    )
+                )
+                for future in futures:
+                    future.result(timeout=60)
+
+            for alias in LAKES:
+                con.execute(f"SELECT * FROM cdc_dml_consumer_create('{alias}', 'catalog_dml_ticks', start_at := 'now')")
+                con.execute(f"SELECT * FROM cdc_ddl_consumer_create('{alias}', 'catalog_ddl', start_at := 'now')")
+
+            assert scalar(con, "SELECT count(*) FROM cdc_list_consumers('alpha')") == 2
+            assert scalar(con, "SELECT count(*) FROM cdc_list_consumers('beta')") == 2
+            assert scalar(con, "SELECT count(*) FROM cdc_list_subscriptions('alpha')") == 2
+            assert scalar(con, "SELECT count(*) FROM cdc_list_subscriptions('beta')") == 2
+            assert scalar(con, "SELECT count(*) FROM cdc_consumer_stats('alpha')") == 2
+            assert scalar(con, "SELECT count(*) FROM cdc_consumer_stats('beta')") == 2
+            con.execute("SELECT * FROM cdc_doctor('alpha')").fetchall()
+            con.execute("SELECT * FROM cdc_doctor('beta')").fetchall()
+
+            con.execute("INSERT INTO alpha.items VALUES (1)")
+            alpha_window = con.execute("SELECT start_snapshot, end_snapshot FROM cdc_window('alpha', 'catalog_dml_ticks')").fetchone()
+            assert alpha_window is not None
+            beta_window = con.execute("SELECT start_snapshot, end_snapshot FROM cdc_window('beta', 'catalog_dml_ticks')").fetchone()
+            assert beta_window is not None and beta_window[0] > beta_window[1], beta_window
+
+            con.execute(
+                "SELECT * FROM cdc_commit('alpha', 'catalog_dml_ticks', ?)",
+                [alpha_window[1]],
+            )
+
+            with psycopg.connect(PG_DSN) as pg:
+                alpha_cursor = pg.execute(
+                    "SELECT last_committed_snapshot FROM ducklake_cdc_alpha.__ducklake_cdc_consumers WHERE consumer_name = 'catalog_dml_ticks'"
+                ).fetchone()
+                beta_cursor = pg.execute(
+                    "SELECT last_committed_snapshot FROM ducklake_cdc_beta.__ducklake_cdc_consumers WHERE consumer_name = 'catalog_dml_ticks'"
+                ).fetchone()
+                assert alpha_cursor == (alpha_window[1],), alpha_cursor
+                assert beta_cursor is not None and beta_cursor[0] != alpha_window[1], beta_cursor
+
+                alpha_trigger = pg.execute(
+                    "SELECT count(*) FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid "
+                    "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                    "WHERE NOT t.tgisinternal AND t.tgname = 'ducklake_cdc_snapshot_notify' "
+                    "AND n.nspname = 'ducklake_alpha' AND c.relname = 'ducklake_snapshot'"
+                ).fetchone()
+                beta_trigger = pg.execute(
+                    "SELECT count(*) FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid "
+                    "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                    "WHERE NOT t.tgisinternal AND t.tgname = 'ducklake_cdc_snapshot_notify' "
+                    "AND n.nspname = 'ducklake_beta' AND c.relname = 'ducklake_snapshot'"
+                ).fetchone()
+                assert alpha_trigger == (1,), alpha_trigger
+                assert beta_trigger == (1,), beta_trigger
+
+                beta_owner_before = pg.execute(
+                    "SELECT owner_token::text FROM ducklake_cdc_beta.__ducklake_cdc_consumers WHERE consumer_name = 'catalog_dml_ticks'"
+                ).fetchone()
+                assert beta_owner_before is not None and beta_owner_before[0] is not None
+
+            con.execute("SELECT * FROM cdc_consumer_force_release('alpha', 'catalog_dml_ticks')")
+            assert scalar(con, "SELECT count(*) FROM cdc_audit_events('alpha')") >= 2
+            assert scalar(con, "SELECT count(*) FROM cdc_audit_events('beta')") >= 1
+
+            with psycopg.connect(PG_DSN) as pg:
+                beta_owner_after = pg.execute(
+                    "SELECT owner_token::text FROM ducklake_cdc_beta.__ducklake_cdc_consumers WHERE consumer_name = 'catalog_dml_ticks'"
+                ).fetchone()
+                assert beta_owner_after == beta_owner_before, (beta_owner_before, beta_owner_after)
+
+            # A fresh runner may reuse the common alias `lake`; explicit schema
+            # identity must still resume Beta's durable cursor only.
+            restarted = duckdb.connect(config={"allow_unsigned_extensions": True, "threads": 1})
+            try:
+                restarted.execute("INSTALL postgres; LOAD postgres; INSTALL ducklake; LOAD ducklake;")
+                restarted.load_extension(str(CDC_EXTENSION))
+                restarted.execute(
+                    f"ATTACH 'ducklake:postgres:{PG_DSN}' AS lake (METADATA_SCHEMA 'ducklake_beta', DATA_PATH '{(Path(tmp) / 'beta').as_posix()}')"
+                )
+                restarted.execute("CALL cdc_configure('lake', state_schema := 'ducklake_cdc_beta', metadata_schema := 'ducklake_beta')")
+                resumed = restarted.execute("SELECT consumer_name, last_committed_snapshot FROM cdc_list_consumers('lake')").fetchall()
+                assert len(resumed) == 2, resumed
+                dml_resumed = [row for row in resumed if row[0] == "catalog_dml_ticks"]
+                assert dml_resumed == [("catalog_dml_ticks", beta_cursor[0])], (resumed, beta_cursor)
+            finally:
+                restarted.close()
+
+            with psycopg.connect(PG_DSN) as pg:
+                pg.execute("DROP SCHEMA ducklake_cdc_alpha CASCADE")
+                pg.commit()
+            assert scalar(con, "SELECT count(*) FROM cdc_list_consumers('beta')") == 2
+        finally:
+            con.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -2702,26 +2702,43 @@ bool SnapshotTouchesSubscriptions(duckdb::Connection &conn, const std::string &c
 	return false;
 }
 
-std::vector<duckdb::Value> NextMatchingSnapshot(duckdb::Connection &conn, const std::string &cache_namespace,
-                                                const std::string &catalog_name, const ConsumerRow &consumer,
-                                                const std::vector<ConsumerSubscriptionRow> &subscriptions) {
+struct SnapshotMatchProbe {
+	duckdb::Value matching_snapshot;
+	int64_t scanned_through;
+
+	SnapshotMatchProbe(duckdb::Value matching_snapshot_p, int64_t scanned_through_p)
+	    : matching_snapshot(std::move(matching_snapshot_p)), scanned_through(scanned_through_p) {
+	}
+};
+
+SnapshotMatchProbe NextMatchingSnapshot(duckdb::Connection &conn, const std::string &cache_namespace,
+                                        const std::string &catalog_name, const ConsumerRow &consumer,
+                                        const std::vector<ConsumerSubscriptionRow> &subscriptions) {
 	if (OnlyDmlTableSubscriptions(subscriptions)) {
 		const auto current_snapshot = CurrentSnapshot(conn, catalog_name);
 		const auto snapshot = FirstDmlSubscribedSnapshot(conn, catalog_name, consumer.last_committed_snapshot,
 		                                                 current_snapshot, subscriptions);
 		if (snapshot != -1) {
-			return {duckdb::Value::BIGINT(snapshot),
-			        duckdb::Value::BIGINT(snapshot - consumer.last_committed_snapshot)};
+			return {duckdb::Value::BIGINT(snapshot), current_snapshot};
 		}
-		return {duckdb::Value(), duckdb::Value()};
+		return {duckdb::Value(), current_snapshot};
 	}
-	auto rows =
-	    conn.Query("SELECT snapshot_id, changes_made FROM " + MetadataTable(catalog_name, "ducklake_snapshot_changes") +
-	               " WHERE snapshot_id > " + std::to_string(consumer.last_committed_snapshot) +
-	               DmlTableSnapshotChangesFilter(subscriptions) + " ORDER BY snapshot_id ASC");
+	const auto current_snapshot = CurrentSnapshot(conn, catalog_name);
+	const auto range_sql = "SELECT snapshot_id, changes_made FROM " +
+	                       NativePostgresMetadataTable("ducklake_snapshot_changes") + " WHERE snapshot_id > " +
+	                       std::to_string(consumer.last_committed_snapshot) +
+	                       " AND snapshot_id <= " + std::to_string(current_snapshot) +
+	                       DmlTableSnapshotChangesFilter(subscriptions) + " ORDER BY snapshot_id ASC";
+	auto rows = MetadataBackendIsPostgres(conn, catalog_name)
+	                ? QueryPostgresMetadata(conn, catalog_name, range_sql)
+	                : conn.Query("SELECT snapshot_id, changes_made FROM " +
+	                             MetadataTable(catalog_name, "ducklake_snapshot_changes") + " WHERE snapshot_id > " +
+	                             std::to_string(consumer.last_committed_snapshot) +
+	                             " AND snapshot_id <= " + std::to_string(current_snapshot) +
+	                             DmlTableSnapshotChangesFilter(subscriptions) + " ORDER BY snapshot_id ASC");
 	ThrowIfQueryFailed(rows);
 	if (!rows) {
-		return {duckdb::Value(), duckdb::Value()};
+		return {duckdb::Value(), current_snapshot};
 	}
 	for (duckdb::idx_t row_idx = 0; row_idx < rows->RowCount(); ++row_idx) {
 		if (rows->GetValue(0, row_idx).IsNull()) {
@@ -2732,11 +2749,35 @@ std::vector<duckdb::Value> NextMatchingSnapshot(duckdb::Connection &conn, const 
 		const auto changes_made = changes_value.IsNull() ? std::string() : changes_value.ToString();
 		if (SnapshotTouchesSubscriptions(conn, cache_namespace, catalog_name, snapshot_id, changes_made,
 		                                 subscriptions)) {
-			return {duckdb::Value::BIGINT(snapshot_id),
-			        duckdb::Value::BIGINT(snapshot_id - consumer.last_committed_snapshot)};
+			return {duckdb::Value::BIGINT(snapshot_id), current_snapshot};
 		}
 	}
-	return {duckdb::Value(), duckdb::Value()};
+	return {duckdb::Value(), current_snapshot};
+}
+
+bool AdvanceDdlCursorPastInspectedSnapshots(duckdb::ClientContext &context, duckdb::Connection &conn,
+                                            const std::string &catalog_name, const ConsumerRow &probed_consumer,
+                                            int64_t inspected_through) {
+	if (probed_consumer.consumer_kind != "ddl" || inspected_through <= probed_consumer.last_committed_snapshot) {
+		return false;
+	}
+
+	const auto cached_token = CachedToken(context, catalog_name, probed_consumer.consumer_name);
+	ConsumerRow owned_consumer;
+	if (!TryUseFreshCachedLease(conn, catalog_name, probed_consumer.consumer_name, cached_token, owned_consumer)) {
+		const auto backend = CachedStateBackend(context, conn, catalog_name);
+		owned_consumer = AcquireLease(conn, catalog_name, probed_consumer.consumer_name, cached_token, backend);
+	}
+	CacheToken(context, catalog_name, probed_consumer.consumer_name, owned_consumer.owner_token.ToString());
+
+	// The subscription scan was performed from probed_consumer's cursor.
+	// A concurrent reset/commit changes that premise, so retry from the new
+	// cursor instead of advancing a range we did not inspect.
+	if (owned_consumer.last_committed_snapshot != probed_consumer.last_committed_snapshot) {
+		return false;
+	}
+	CommitConsumerSnapshotWithConnection(context, conn, catalog_name, probed_consumer.consumer_name, inspected_through);
+	return true;
 }
 
 duckdb::unique_ptr<duckdb::FunctionData> ListenWaitBind(duckdb::ClientContext &context,
@@ -2787,10 +2828,18 @@ WaitForNextSnapshotWithSubscriptions(duckdb::ClientContext &context, duckdb::Con
 			throw duckdb::InterruptException();
 		}
 		const auto row = LoadConsumerOrThrow(conn, catalog_name, consumer_name);
-		const auto next_matching =
-		    NextMatchingSnapshot(conn, ConnectionCachePrefix(context), catalog_name, row, subscriptions);
-		if (!next_matching.empty() && !next_matching[0].IsNull()) {
-			return next_matching;
+		const auto probe = NextMatchingSnapshot(conn, ConnectionCachePrefix(context), catalog_name, row, subscriptions);
+		if (!probe.matching_snapshot.IsNull()) {
+			const auto snapshot = probe.matching_snapshot.GetValue<int64_t>();
+			return {probe.matching_snapshot, duckdb::Value::BIGINT(snapshot - row.last_committed_snapshot)};
+		}
+		if (row.consumer_kind == "ddl" && probe.scanned_through > row.last_committed_snapshot) {
+			if (AdvanceDdlCursorPastInspectedSnapshots(context, conn, catalog_name, row, probe.scanned_through)) {
+				// Completing this empty window is observable progress. Return
+				// to the caller instead of holding the lease through another
+				// long wait without a heartbeat.
+				return {duckdb::Value()};
+			}
 		}
 		const auto now = std::chrono::steady_clock::now();
 		if (now >= deadline || clamped_timeout_ms == 0) {
@@ -3355,6 +3404,23 @@ std::vector<duckdb::Value> ReadWindowWithConnection(duckdb::ClientContext &conte
 	const bool is_dml = consumer_kind == "dml";
 
 	if (is_dml) {
+		// DuckDB's Postgres scanner cannot push the aggregate in
+		// ResolveDmlWindowIndexed into the remote query. Avoid copying the
+		// complete snapshot metadata history when this consumer is already at
+		// the catalogue head—the steady-state path for non-blocking relays.
+		if (MetadataBackendIsPostgres(conn, data.catalog_name)) {
+			const auto current_snapshot = CurrentSnapshot(conn, data.catalog_name);
+			if (last_snapshot == current_snapshot) {
+				CacheDmlSafeCommitRange(context, data.catalog_name, data.consumer_name, last_snapshot, last_snapshot);
+				return {duckdb::Value::BIGINT(last_snapshot + 1),
+				        duckdb::Value::BIGINT(last_snapshot),
+				        duckdb::Value::BOOLEAN(false),
+				        duckdb::Value::BIGINT(row.last_committed_schema_version),
+				        duckdb::Value::BOOLEAN(false),
+				        duckdb::Value::BOOLEAN(false),
+				        duckdb::Value()};
+			}
+		}
 		const auto subscriptions = LoadDmlConsumerSubscriptions(conn, data.catalog_name, data.consumer_name);
 		const auto resolved =
 		    ResolveDmlWindowIndexed(conn, data.catalog_name, last_snapshot, data.max_snapshots, subscriptions);

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -314,14 +314,16 @@ std::string ConnectionCachePrefix(duckdb::ClientContext &context) {
 	return out.str();
 }
 
-std::string TokenCacheKey(duckdb::ClientContext &context, const std::string &catalog_name,
+std::string TokenCacheKey(duckdb::ClientContext &context, duckdb::Connection &conn, const std::string &catalog_name,
                           const std::string &consumer_name) {
-	return ConnectionCachePrefix(context) + ":" + catalog_name + ":" + consumer_name;
+	const auto state = ResolveCdcCatalogState(conn, catalog_name);
+	const auto identity = state.attachment_identity.empty() ? catalog_name : state.attachment_identity;
+	return ConnectionCachePrefix(context) + ":" + identity + ":" + state.state_schema + ":" + consumer_name;
 }
 
-std::string DmlSafeCommitKey(duckdb::ClientContext &context, const std::string &catalog_name,
+std::string DmlSafeCommitKey(duckdb::ClientContext &context, duckdb::Connection &conn, const std::string &catalog_name,
                              const std::string &consumer_name) {
-	return TokenCacheKey(context, catalog_name, consumer_name);
+	return TokenCacheKey(context, conn, catalog_name, consumer_name);
 }
 
 std::string AdaptiveListenKey(const std::string &catalog_name, const std::string &consumer_name,
@@ -329,41 +331,42 @@ std::string AdaptiveListenKey(const std::string &catalog_name, const std::string
 	return catalog_name + ":" + consumer_name + ":" + stream_key;
 }
 
-std::string CachedToken(duckdb::ClientContext &context, const std::string &catalog_name,
+std::string CachedToken(duckdb::ClientContext &context, duckdb::Connection &conn, const std::string &catalog_name,
                         const std::string &consumer_name) {
 	std::lock_guard<std::mutex> guard(TOKEN_CACHE_MUTEX);
-	auto entry = TOKEN_CACHE.find(TokenCacheKey(context, catalog_name, consumer_name));
+	auto entry = TOKEN_CACHE.find(TokenCacheKey(context, conn, catalog_name, consumer_name));
 	if (entry == TOKEN_CACHE.end()) {
 		return "";
 	}
 	return entry->second;
 }
 
-void CacheToken(duckdb::ClientContext &context, const std::string &catalog_name, const std::string &consumer_name,
-                const std::string &token) {
+void CacheToken(duckdb::ClientContext &context, duckdb::Connection &conn, const std::string &catalog_name,
+                const std::string &consumer_name, const std::string &token) {
 	std::lock_guard<std::mutex> guard(TOKEN_CACHE_MUTEX);
-	TOKEN_CACHE[TokenCacheKey(context, catalog_name, consumer_name)] = token;
+	TOKEN_CACHE[TokenCacheKey(context, conn, catalog_name, consumer_name)] = token;
 }
 
-void EraseCachedToken(duckdb::ClientContext &context, const std::string &catalog_name,
+void EraseCachedToken(duckdb::ClientContext &context, duckdb::Connection &conn, const std::string &catalog_name,
                       const std::string &consumer_name) {
 	std::lock_guard<std::mutex> guard(TOKEN_CACHE_MUTEX);
-	TOKEN_CACHE.erase(TokenCacheKey(context, catalog_name, consumer_name));
+	TOKEN_CACHE.erase(TokenCacheKey(context, conn, catalog_name, consumer_name));
 }
 
-void CacheDmlSafeCommitRange(duckdb::ClientContext &context, const std::string &catalog_name,
+void CacheDmlSafeCommitRange(duckdb::ClientContext &context, duckdb::Connection &conn, const std::string &catalog_name,
                              const std::string &consumer_name, int64_t cursor, int64_t safe_until) {
 	std::lock_guard<std::mutex> guard(DML_SAFE_COMMIT_MUTEX);
 	DmlSafeCommitRange range;
 	range.cursor = cursor;
 	range.safe_until = safe_until;
-	DML_SAFE_COMMIT_RANGES[DmlSafeCommitKey(context, catalog_name, consumer_name)] = range;
+	DML_SAFE_COMMIT_RANGES[DmlSafeCommitKey(context, conn, catalog_name, consumer_name)] = range;
 }
 
-bool HasCachedDmlSafeCommitRange(duckdb::ClientContext &context, const std::string &catalog_name,
-                                 const std::string &consumer_name, int64_t cursor, int64_t requested_snapshot) {
+bool HasCachedDmlSafeCommitRange(duckdb::ClientContext &context, duckdb::Connection &conn,
+                                 const std::string &catalog_name, const std::string &consumer_name, int64_t cursor,
+                                 int64_t requested_snapshot) {
 	std::lock_guard<std::mutex> guard(DML_SAFE_COMMIT_MUTEX);
-	const auto entry = DML_SAFE_COMMIT_RANGES.find(DmlSafeCommitKey(context, catalog_name, consumer_name));
+	const auto entry = DML_SAFE_COMMIT_RANGES.find(DmlSafeCommitKey(context, conn, catalog_name, consumer_name));
 	if (entry == DML_SAFE_COMMIT_RANGES.end()) {
 		return false;
 	}
@@ -462,13 +465,12 @@ std::string NativePostgresTable(const std::string &schema_name, const std::strin
 	return QuoteIdentifier(schema_name) + "." + QuoteIdentifier(table_name);
 }
 
-std::string NativePostgresStateTable(const std::string &table_name, bool use_state_schema) {
-	const auto schema_name = use_state_schema ? STATE_SCHEMA : "public";
-	return NativePostgresTable(schema_name, table_name);
+std::string NativePostgresStateTable(const std::string &state_schema, const std::string &table_name) {
+	return NativePostgresTable(state_schema, table_name);
 }
 
-std::string NativePostgresMetadataTable(const std::string &table_name) {
-	return NativePostgresTable("public", table_name);
+std::string NativePostgresMetadataTable(const std::string &metadata_schema, const std::string &table_name) {
+	return NativePostgresTable(metadata_schema, table_name);
 }
 
 void PostgresExecuteChecked(duckdb::Connection &conn, const std::string &catalog_name, const std::string &sql) {
@@ -659,6 +661,62 @@ duckdb::Value NamedParameterValue(duckdb::TableFunctionBindInput &input, const s
 	return entry->second;
 }
 
+//===--------------------------------------------------------------------===//
+// cdc_configure
+//===--------------------------------------------------------------------===//
+
+struct CdcConfigureData : public duckdb::TableFunctionData {
+	std::string catalog_name;
+	std::string state_schema;
+	std::string metadata_schema;
+
+	duckdb::unique_ptr<duckdb::FunctionData> Copy() const override {
+		auto result = duckdb::make_uniq<CdcConfigureData>();
+		result->catalog_name = catalog_name;
+		result->state_schema = state_schema;
+		result->metadata_schema = metadata_schema;
+		return std::move(result);
+	}
+
+	bool Equals(const duckdb::FunctionData &other) const override {
+		return this == &other;
+	}
+};
+
+duckdb::unique_ptr<duckdb::FunctionData> CdcConfigureBind(duckdb::ClientContext &context,
+                                                          duckdb::TableFunctionBindInput &input,
+                                                          duckdb::vector<duckdb::LogicalType> &return_types,
+                                                          duckdb::vector<duckdb::string> &names) {
+	if (input.inputs.size() != 1) {
+		throw duckdb::BinderException("cdc_configure requires catalog");
+	}
+	auto result = duckdb::make_uniq<CdcConfigureData>();
+	result->catalog_name = GetStringArg(input.inputs[0], "catalog");
+	const auto state_schema = NamedParameterValue(input, "state_schema");
+	const auto metadata_schema = NamedParameterValue(input, "metadata_schema");
+	if (state_schema.IsNull() || metadata_schema.IsNull()) {
+		throw duckdb::BinderException("cdc_configure requires state_schema and metadata_schema");
+	}
+	result->state_schema = state_schema.GetValue<std::string>();
+	result->metadata_schema = metadata_schema.GetValue<std::string>();
+	names = {"catalog_name", "state_schema", "metadata_schema"};
+	return_types = {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR};
+	return std::move(result);
+}
+
+duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcConfigureInit(duckdb::ClientContext &context,
+                                                                      duckdb::TableFunctionInitInput &input) {
+	auto result = duckdb::make_uniq<RowScanState>();
+	auto &data = input.bind_data->Cast<CdcConfigureData>();
+	duckdb::Connection conn(*context.db);
+	ConfigureCdcInternalConnection(conn);
+	CheckCatalogOrThrow(conn, data.catalog_name);
+	const auto configured = ConfigureCdcCatalogState(conn, data.catalog_name, data.state_schema, data.metadata_schema);
+	result->rows.push_back({duckdb::Value(configured.catalog_name), duckdb::Value(configured.state_schema),
+	                        duckdb::Value(configured.metadata_schema)});
+	return std::move(result);
+}
+
 void ConsumerCreateReturnTypes(duckdb::vector<duckdb::LogicalType> &return_types,
                                duckdb::vector<duckdb::string> &names) {
 	names = {"consumer_name",
@@ -762,10 +820,10 @@ duckdb::Value OptionalQualifiedName(const std::string &scope_kind, const duckdb:
 
 bool ResolveSchemaByNameAt(duckdb::Connection &conn, const std::string &catalog_name, const std::string &schema_name,
                            int64_t snapshot_id, int64_t &schema_id) {
-	auto result =
-	    conn.Query("SELECT schema_id FROM " + MetadataTable(catalog_name, "ducklake_schema") + " WHERE schema_name = " +
-	               QuoteLiteral(schema_name) + " AND begin_snapshot <= " + std::to_string(snapshot_id) +
-	               " AND (end_snapshot IS NULL OR end_snapshot > " + std::to_string(snapshot_id) + ") LIMIT 1");
+	auto result = conn.Query(
+	    "SELECT schema_id FROM " + MetadataTable(conn, catalog_name, "ducklake_schema") +
+	    " WHERE schema_name = " + QuoteLiteral(schema_name) + " AND begin_snapshot <= " + std::to_string(snapshot_id) +
+	    " AND (end_snapshot IS NULL OR end_snapshot > " + std::to_string(snapshot_id) + ") LIMIT 1");
 	if (!result || result->HasError() || result->RowCount() == 0 || result->GetValue(0, 0).IsNull()) {
 		return false;
 	}
@@ -775,10 +833,10 @@ bool ResolveSchemaByNameAt(duckdb::Connection &conn, const std::string &catalog_
 
 bool ResolveSchemaByIdAt(duckdb::Connection &conn, const std::string &catalog_name, int64_t schema_id,
                          int64_t snapshot_id, std::string &schema_name) {
-	auto result =
-	    conn.Query("SELECT schema_name FROM " + MetadataTable(catalog_name, "ducklake_schema") + " WHERE schema_id = " +
-	               std::to_string(schema_id) + " AND begin_snapshot <= " + std::to_string(snapshot_id) +
-	               " AND (end_snapshot IS NULL OR end_snapshot > " + std::to_string(snapshot_id) + ") LIMIT 1");
+	auto result = conn.Query(
+	    "SELECT schema_name FROM " + MetadataTable(conn, catalog_name, "ducklake_schema") +
+	    " WHERE schema_id = " + std::to_string(schema_id) + " AND begin_snapshot <= " + std::to_string(snapshot_id) +
+	    " AND (end_snapshot IS NULL OR end_snapshot > " + std::to_string(snapshot_id) + ") LIMIT 1");
 	if (!result || result->HasError() || result->RowCount() == 0 || result->GetValue(0, 0).IsNull()) {
 		return false;
 	}
@@ -788,13 +846,14 @@ bool ResolveSchemaByIdAt(duckdb::Connection &conn, const std::string &catalog_na
 
 bool ResolveTableByIdAt(duckdb::Connection &conn, const std::string &catalog_name, int64_t table_id,
                         int64_t snapshot_id, int64_t &schema_id, std::string &qualified_name) {
-	auto result = conn.Query(
-	    "SELECT s.schema_id, s.schema_name || '.' || t.table_name FROM " +
-	    MetadataTable(catalog_name, "ducklake_table") + " t JOIN " + MetadataTable(catalog_name, "ducklake_schema") +
-	    " s USING (schema_id) WHERE t.table_id = " + std::to_string(table_id) + " AND t.begin_snapshot <= " +
-	    std::to_string(snapshot_id) + " AND (t.end_snapshot IS NULL OR t.end_snapshot > " +
-	    std::to_string(snapshot_id) + ") AND s.begin_snapshot <= " + std::to_string(snapshot_id) +
-	    " AND (s.end_snapshot IS NULL OR s.end_snapshot > " + std::to_string(snapshot_id) + ") LIMIT 1");
+	auto result =
+	    conn.Query("SELECT s.schema_id, s.schema_name || '.' || t.table_name FROM " +
+	               MetadataTable(conn, catalog_name, "ducklake_table") + " t JOIN " +
+	               MetadataTable(conn, catalog_name, "ducklake_schema") + " s USING (schema_id) WHERE t.table_id = " +
+	               std::to_string(table_id) + " AND t.begin_snapshot <= " + std::to_string(snapshot_id) +
+	               " AND (t.end_snapshot IS NULL OR t.end_snapshot > " + std::to_string(snapshot_id) +
+	               ") AND s.begin_snapshot <= " + std::to_string(snapshot_id) +
+	               " AND (s.end_snapshot IS NULL OR s.end_snapshot > " + std::to_string(snapshot_id) + ") LIMIT 1");
 	if (!result || result->HasError() || result->RowCount() == 0 || result->GetValue(0, 0).IsNull() ||
 	    result->GetValue(1, 0).IsNull()) {
 		return false;
@@ -812,8 +871,8 @@ bool StartAtMeansBeginning(const std::string &start_at) {
 bool ResolveFirstLiveTableById(duckdb::Connection &conn, const std::string &catalog_name, int64_t table_id,
                                int64_t &snapshot_id, int64_t &schema_id, std::string &qualified_name) {
 	auto result = conn.Query("SELECT t.begin_snapshot, s.schema_id, s.schema_name || '.' || t.table_name FROM " +
-	                         MetadataTable(catalog_name, "ducklake_table") + " t JOIN " +
-	                         MetadataTable(catalog_name, "ducklake_schema") +
+	                         MetadataTable(conn, catalog_name, "ducklake_table") + " t JOIN " +
+	                         MetadataTable(conn, catalog_name, "ducklake_schema") +
 	                         " s USING (schema_id) WHERE t.table_id = " + std::to_string(table_id) +
 	                         " AND s.begin_snapshot <= t.begin_snapshot "
 	                         "AND (s.end_snapshot IS NULL OR s.end_snapshot > t.begin_snapshot) "
@@ -839,8 +898,8 @@ bool ResolveFirstLiveTableByName(duckdb::Connection &conn, const std::string &ca
 	const auto schema_name = qualified_name.substr(0, dot);
 	const auto table_name = qualified_name.substr(dot + 1);
 	auto result = conn.Query("SELECT t.begin_snapshot, s.schema_id, t.table_id FROM " +
-	                         MetadataTable(catalog_name, "ducklake_table") + " t JOIN " +
-	                         MetadataTable(catalog_name, "ducklake_schema") +
+	                         MetadataTable(conn, catalog_name, "ducklake_table") + " t JOIN " +
+	                         MetadataTable(conn, catalog_name, "ducklake_schema") +
 	                         " s USING (schema_id) WHERE s.schema_name = " + QuoteLiteral(schema_name) +
 	                         " AND t.table_name = " + QuoteLiteral(table_name) +
 	                         " AND s.begin_snapshot <= t.begin_snapshot "
@@ -1450,7 +1509,7 @@ std::vector<duckdb::Value> ReleaseConsumer(duckdb::ClientContext &context, const
 	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, data.catalog_name);
 	BootstrapConsumerStateOrThrow(conn, data.catalog_name);
-	const auto cached_token = CachedToken(context, data.catalog_name, data.consumer_name);
+	const auto cached_token = CachedToken(context, conn, data.catalog_name, data.consumer_name);
 	auto row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
 	if (cached_token.empty() || row.owner_token.IsNull() || row.owner_token.ToString() != cached_token) {
 		ThrowBusy(conn, data.catalog_name, data.consumer_name);
@@ -1465,7 +1524,7 @@ std::vector<duckdb::Value> ReleaseConsumer(duckdb::ClientContext &context, const
 	if (!row.owner_token.IsNull()) {
 		ThrowBusy(conn, data.catalog_name, data.consumer_name);
 	}
-	EraseCachedToken(context, data.catalog_name, data.consumer_name);
+	EraseCachedToken(context, conn, data.catalog_name, data.consumer_name);
 	const auto details = "{\"released_token\":\"" + JsonEscape(cached_token) + "\"}";
 	InsertAuditRow(conn, data.catalog_name, "consumer_release", data.consumer_name, row.consumer_id, details);
 	return {duckdb::Value(data.consumer_name), duckdb::Value::BIGINT(row.consumer_id), duckdb::Value(cached_token)};
@@ -1688,7 +1747,7 @@ int64_t RequiredInt64(const duckdb::Value &value, const std::string &description
 DmlWindowResolution ResolveDmlWindowIndexed(duckdb::Connection &conn, const std::string &catalog_name,
                                             int64_t last_snapshot, int64_t max_snapshots,
                                             const std::vector<ConsumerSubscriptionRow> &subscriptions) {
-	const auto snapshot_table = MetadataTable(catalog_name, "ducklake_snapshot");
+	const auto snapshot_table = MetadataTable(conn, catalog_name, "ducklake_snapshot");
 	const auto last_snapshot_sql = std::to_string(last_snapshot);
 	auto result =
 	    conn.Query("WITH snapshot_bounds AS ("
@@ -1748,8 +1807,8 @@ DmlWindowResolution ResolveDmlWindowIndexed(duckdb::Connection &conn, const std:
 
 WindowResolution ResolveWindowFast(duckdb::Connection &conn, const std::string &catalog_name, int64_t last_snapshot,
                                    int64_t max_snapshots) {
-	const auto snapshot_table = MetadataTable(catalog_name, "ducklake_snapshot");
-	const auto changes_table = MetadataTable(catalog_name, "ducklake_snapshot_changes");
+	const auto snapshot_table = MetadataTable(conn, catalog_name, "ducklake_snapshot");
+	const auto changes_table = MetadataTable(conn, catalog_name, "ducklake_snapshot_changes");
 	const auto last_snapshot_sql = std::to_string(last_snapshot);
 	const auto max_snapshots_sql = std::to_string(max_snapshots);
 	const auto schema_change_filter = "(sc.changes_made LIKE 'created_%' OR sc.changes_made LIKE '%,created_%' OR "
@@ -1887,7 +1946,7 @@ void ValidateCommitSnapshot(duckdb::Connection &conn, const std::string &catalog
 		                                    static_cast<long long>(snapshot_id), consumer_name,
 		                                    static_cast<long long>(current_cursor));
 	}
-	const auto snapshot_table = MetadataTable(catalog_name, "ducklake_snapshot");
+	const auto snapshot_table = MetadataTable(conn, catalog_name, "ducklake_snapshot");
 	auto result =
 	    conn.Query("SELECT count(*) FROM " + snapshot_table + " WHERE snapshot_id = " + std::to_string(snapshot_id));
 	if (SingleInt64(*result, "commit snapshot existence") == 0) {
@@ -1973,10 +2032,13 @@ bool TryCommitPostgresNative(duckdb::Connection &conn, const std::string &catalo
 	if (cached_token.empty()) {
 		return false;
 	}
-	const auto use_state_schema = StateSchemaExists(conn, catalog_name);
-	const auto consumers = NativePostgresStateTable(CONSUMERS_TABLE, use_state_schema);
-	const auto attached_consumers = StateTable(catalog_name, CONSUMERS_TABLE, use_state_schema);
-	const auto snapshot_table = NativePostgresMetadataTable("ducklake_snapshot");
+	if (!StateSchemaExists(conn, catalog_name)) {
+		return false;
+	}
+	const auto state = ResolveCdcCatalogState(conn, catalog_name);
+	const auto consumers = NativePostgresStateTable(state.state_schema, CONSUMERS_TABLE);
+	const auto attached_consumers = StateTable(catalog_name, CONSUMERS_TABLE, state.state_schema);
+	const auto snapshot_table = NativePostgresMetadataTable(state.metadata_schema, "ducklake_snapshot");
 	const auto snapshot_sql = std::to_string(snapshot_id);
 	const auto update_sql =
 	    "UPDATE " + consumers + " SET last_committed_snapshot = " + snapshot_sql +
@@ -2000,18 +2062,18 @@ std::vector<duckdb::Value> CommitWindowWithConnection(duckdb::ClientContext &con
 	CheckCatalogOrThrow(conn, data.catalog_name);
 
 	const auto backend = CachedStateBackend(context, conn, data.catalog_name);
-	const auto cached_token = CachedToken(context, data.catalog_name, data.consumer_name);
+	const auto cached_token = CachedToken(context, conn, data.catalog_name, data.consumer_name);
 	// Look up the consumer once before any UPDATE: the per-subscribed-table
 	// schema-shape boundary check must happen on every code path (fast,
 	// postgres-native, legacy) and must precede any state mutation.
 	auto initial_row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
-	if (!HasCachedDmlSafeCommitRange(context, data.catalog_name, data.consumer_name,
+	if (!HasCachedDmlSafeCommitRange(context, conn, data.catalog_name, data.consumer_name,
 	                                 initial_row.last_committed_snapshot, data.snapshot_id)) {
 		ValidateDmlConsumerShapeBoundary(conn, data.catalog_name, initial_row, data.snapshot_id);
 	}
 	if (SupportsUpdateReturning(backend)) {
 		const auto consumers = StateTable(conn, data.catalog_name, CONSUMERS_TABLE);
-		const auto snapshot_table = MetadataTable(data.catalog_name, "ducklake_snapshot");
+		const auto snapshot_table = MetadataTable(conn, data.catalog_name, "ducklake_snapshot");
 		auto fast_commit = conn.Query(
 		    "UPDATE " + consumers + " SET last_committed_snapshot = " + std::to_string(data.snapshot_id) +
 		    ", last_committed_schema_version = (SELECT schema_version FROM " + snapshot_table +
@@ -2109,7 +2171,7 @@ std::vector<duckdb::Value> HeartbeatConsumer(duckdb::ClientContext &context, con
 	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, data.catalog_name);
 	const auto consumers = StateTable(conn, data.catalog_name, CONSUMERS_TABLE);
-	const auto cached_token = CachedToken(context, data.catalog_name, data.consumer_name);
+	const auto cached_token = CachedToken(context, conn, data.catalog_name, data.consumer_name);
 	auto row = LoadConsumerOrThrow(conn, data.catalog_name, data.consumer_name);
 	if (cached_token.empty() || row.owner_token.IsNull() || row.owner_token.ToString() != cached_token) {
 		ThrowBusy(conn, data.catalog_name, data.consumer_name);
@@ -2342,10 +2404,10 @@ std::vector<DecodedSnapshotChange> LoadDecodedSnapshotChanges(duckdb::Connection
 		return cached;
 	}
 
-	auto rows =
-	    conn.Query("SELECT snapshot_id, changes_made FROM " + MetadataTable(catalog_name, "ducklake_snapshot_changes") +
-	               " WHERE snapshot_id > " + std::to_string(from_snapshot) +
-	               " AND snapshot_id <= " + std::to_string(to_snapshot) + " ORDER BY snapshot_id ASC");
+	auto rows = conn.Query("SELECT snapshot_id, changes_made FROM " +
+	                       MetadataTable(conn, catalog_name, "ducklake_snapshot_changes") + " WHERE snapshot_id > " +
+	                       std::to_string(from_snapshot) + " AND snapshot_id <= " + std::to_string(to_snapshot) +
+	                       " ORDER BY snapshot_id ASC");
 	ThrowIfQueryFailed(rows);
 	if (!rows) {
 		return {};
@@ -2724,16 +2786,17 @@ SnapshotMatchProbe NextMatchingSnapshot(duckdb::Connection &conn, const std::str
 		return {duckdb::Value(), current_snapshot};
 	}
 	const auto current_snapshot = CurrentSnapshot(conn, catalog_name);
+	const auto metadata_schema = ResolveCdcCatalogState(conn, catalog_name).metadata_schema;
 	const auto range_sql = "SELECT snapshot_id, changes_made FROM " +
-	                       NativePostgresMetadataTable("ducklake_snapshot_changes") + " WHERE snapshot_id > " +
-	                       std::to_string(consumer.last_committed_snapshot) +
+	                       NativePostgresMetadataTable(metadata_schema, "ducklake_snapshot_changes") +
+	                       " WHERE snapshot_id > " + std::to_string(consumer.last_committed_snapshot) +
 	                       " AND snapshot_id <= " + std::to_string(current_snapshot) +
 	                       DmlTableSnapshotChangesFilter(subscriptions) + " ORDER BY snapshot_id ASC";
 	auto rows = MetadataBackendIsPostgres(conn, catalog_name)
 	                ? QueryPostgresMetadata(conn, catalog_name, range_sql)
 	                : conn.Query("SELECT snapshot_id, changes_made FROM " +
-	                             MetadataTable(catalog_name, "ducklake_snapshot_changes") + " WHERE snapshot_id > " +
-	                             std::to_string(consumer.last_committed_snapshot) +
+	                             MetadataTable(conn, catalog_name, "ducklake_snapshot_changes") +
+	                             " WHERE snapshot_id > " + std::to_string(consumer.last_committed_snapshot) +
 	                             " AND snapshot_id <= " + std::to_string(current_snapshot) +
 	                             DmlTableSnapshotChangesFilter(subscriptions) + " ORDER BY snapshot_id ASC");
 	ThrowIfQueryFailed(rows);
@@ -2762,13 +2825,13 @@ bool AdvanceDdlCursorPastInspectedSnapshots(duckdb::ClientContext &context, duck
 		return false;
 	}
 
-	const auto cached_token = CachedToken(context, catalog_name, probed_consumer.consumer_name);
+	const auto cached_token = CachedToken(context, conn, catalog_name, probed_consumer.consumer_name);
 	ConsumerRow owned_consumer;
 	if (!TryUseFreshCachedLease(conn, catalog_name, probed_consumer.consumer_name, cached_token, owned_consumer)) {
 		const auto backend = CachedStateBackend(context, conn, catalog_name);
 		owned_consumer = AcquireLease(conn, catalog_name, probed_consumer.consumer_name, cached_token, backend);
 	}
-	CacheToken(context, catalog_name, probed_consumer.consumer_name, owned_consumer.owner_token.ToString());
+	CacheToken(context, conn, catalog_name, probed_consumer.consumer_name, owned_consumer.owner_token.ToString());
 
 	// The subscription scan was performed from probed_consumer's cursor.
 	// A concurrent reset/commit changes that premise, so retry from the new
@@ -2821,7 +2884,7 @@ WaitForNextSnapshotWithSubscriptions(duckdb::ClientContext &context, duckdb::Con
 	const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(clamped_timeout_ms);
 #ifndef _WIN32
 	const auto pg_dsn = MetadataBackendIsPostgres(conn, catalog_name) ? PostgresMetadataDsn(conn, catalog_name) : "";
-	PostgresSnapshotListener pg_listener(pg_dsn, SnapshotNotifyChannel(catalog_name));
+	PostgresSnapshotListener pg_listener(pg_dsn, SnapshotNotifyChannel(conn, catalog_name));
 #endif
 	while (true) {
 		if (context.interrupted) {
@@ -3148,10 +3211,10 @@ bool ResolveCurrentTableName(duckdb::Connection &conn, const std::string &catalo
 	const auto schema_name = qualified_name.substr(0, dot);
 	const auto table_name = qualified_name.substr(dot + 1);
 	auto result =
-	    conn.Query("SELECT s.schema_id, t.table_id FROM " + MetadataTable(catalog_name, "ducklake_table") + " t JOIN " +
-	               MetadataTable(catalog_name, "ducklake_schema") + " s USING (schema_id) WHERE s.schema_name = " +
-	               QuoteLiteral(schema_name) + " AND t.table_name = " + QuoteLiteral(table_name) +
-	               " AND t.begin_snapshot <= " + std::to_string(snapshot_id) +
+	    conn.Query("SELECT s.schema_id, t.table_id FROM " + MetadataTable(conn, catalog_name, "ducklake_table") +
+	               " t JOIN " + MetadataTable(conn, catalog_name, "ducklake_schema") +
+	               " s USING (schema_id) WHERE s.schema_name = " + QuoteLiteral(schema_name) + " AND t.table_name = " +
+	               QuoteLiteral(table_name) + " AND t.begin_snapshot <= " + std::to_string(snapshot_id) +
 	               " AND (t.end_snapshot IS NULL OR t.end_snapshot > " + std::to_string(snapshot_id) +
 	               ") AND s.begin_snapshot <= " + std::to_string(snapshot_id) +
 	               " AND (s.end_snapshot IS NULL OR s.end_snapshot > " + std::to_string(snapshot_id) + ") LIMIT 1");
@@ -3391,7 +3454,7 @@ std::vector<duckdb::Value> ReadWindowWithConnection(duckdb::ClientContext &conte
 		throw duckdb::InvalidInputException("cdc_window max_snapshots must be >= 1");
 	}
 
-	const auto cached_token = CachedToken(context, data.catalog_name, data.consumer_name);
+	const auto cached_token = CachedToken(context, conn, data.catalog_name, data.consumer_name);
 	ConsumerRow row;
 	if (!TryUseFreshCachedLease(conn, data.catalog_name, data.consumer_name, cached_token, row)) {
 		const auto backend = CachedStateBackend(context, conn, data.catalog_name);
@@ -3400,7 +3463,7 @@ std::vector<duckdb::Value> ReadWindowWithConnection(duckdb::ClientContext &conte
 	const auto last_snapshot = row.last_committed_snapshot;
 	const auto consumer_kind = row.consumer_kind;
 	const auto owner_token = row.owner_token.ToString();
-	CacheToken(context, data.catalog_name, data.consumer_name, owner_token);
+	CacheToken(context, conn, data.catalog_name, data.consumer_name, owner_token);
 	const bool is_dml = consumer_kind == "dml";
 
 	if (is_dml) {
@@ -3411,7 +3474,8 @@ std::vector<duckdb::Value> ReadWindowWithConnection(duckdb::ClientContext &conte
 		if (MetadataBackendIsPostgres(conn, data.catalog_name)) {
 			const auto current_snapshot = CurrentSnapshot(conn, data.catalog_name);
 			if (last_snapshot == current_snapshot) {
-				CacheDmlSafeCommitRange(context, data.catalog_name, data.consumer_name, last_snapshot, last_snapshot);
+				CacheDmlSafeCommitRange(context, conn, data.catalog_name, data.consumer_name, last_snapshot,
+				                        last_snapshot);
 				return {duckdb::Value::BIGINT(last_snapshot + 1),
 				        duckdb::Value::BIGINT(last_snapshot),
 				        duckdb::Value::BOOLEAN(false),
@@ -3450,7 +3514,7 @@ std::vector<duckdb::Value> ReadWindowWithConnection(duckdb::ClientContext &conte
 				                         end_schema_version, resolved.boundary_snapshot, boundary_schema_version);
 			}
 		}
-		CacheDmlSafeCommitRange(context, data.catalog_name, data.consumer_name, last_snapshot,
+		CacheDmlSafeCommitRange(context, conn, data.catalog_name, data.consumer_name, last_snapshot,
 		                        resolved.has_changes ? resolved.end_snapshot : last_snapshot);
 		return {duckdb::Value::BIGINT(resolved.start_snapshot),
 		        duckdb::Value::BIGINT(resolved.end_snapshot),
@@ -3566,7 +3630,7 @@ std::vector<duckdb::Value> ReadWindowWithConnection(duckdb::ClientContext &conte
 		                            RequiredInt64(ddl_schema_change_version, "schema_version"));
 	}
 	if (is_dml) {
-		CacheDmlSafeCommitRange(context, data.catalog_name, data.consumer_name, last_snapshot,
+		CacheDmlSafeCommitRange(context, conn, data.catalog_name, data.consumer_name, last_snapshot,
 		                        has_changes ? end_snapshot : last_snapshot);
 	}
 	return {duckdb::Value::BIGINT(start_snapshot),
@@ -3708,6 +3772,13 @@ void RecordConsumerListenResult(const std::string &catalog_name, const std::stri
 void RegisterConsumerFunctions(duckdb::ExtensionLoader &loader) {
 	const auto varchar_list = duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR);
 	const auto bigint_list = duckdb::LogicalType::LIST(duckdb::LogicalType::BIGINT);
+	duckdb::TableFunction configure_function("cdc_configure",
+	                                         duckdb::vector<duckdb::LogicalType> {duckdb::LogicalType::VARCHAR},
+	                                         RowScanExecute, CdcConfigureBind, CdcConfigureInit);
+	configure_function.named_parameters["state_schema"] = duckdb::LogicalType::VARCHAR;
+	configure_function.named_parameters["metadata_schema"] = duckdb::LogicalType::VARCHAR;
+	loader.RegisterFunction(configure_function);
+
 	duckdb::TableFunction ddl_create_function(
 	    "cdc_ddl_consumer_create",
 	    duckdb::vector<duckdb::LogicalType> {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR},

--- a/src/ddl.cpp
+++ b/src/ddl.cpp
@@ -1268,9 +1268,13 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcDdlInit(duckdb::ClientCo
 	auto result = duckdb::make_uniq<RowScanState>();
 	auto &data = input.bind_data->Cast<CdcDdlData>();
 	auto max_snapshots = data.max_snapshots;
-	if (data.listen && !data.explicit_window) {
+	if (!data.explicit_window) {
+		// Both stateful entry points must probe for subscription-relevant DDL.
+		// A non-blocking read uses a zero timeout; the probe still durably
+		// advances a DDL cursor across an inspected DML-only window.
+		const auto timeout_ms = data.listen ? data.timeout_ms : 0;
 		auto ready =
-		    WaitForConsumerSnapshot(context, data.catalog_name, data.consumer_name, data.timeout_ms, data.poll_min_ms);
+		    WaitForConsumerSnapshot(context, data.catalog_name, data.consumer_name, timeout_ms, data.poll_min_ms);
 		if (ready.empty() || ready[0].IsNull()) {
 			return std::move(result);
 		}

--- a/src/ddl.cpp
+++ b/src/ddl.cpp
@@ -90,9 +90,10 @@ struct DdlObject {
 
 DdlObject LookupSchemaByName(duckdb::Connection &conn, const std::string &catalog_name, int64_t snapshot_id,
                              const std::string &schema_name) {
-	auto result = conn.Query("SELECT schema_id, schema_name FROM " + MetadataTable(catalog_name, "ducklake_schema") +
-	                         " WHERE begin_snapshot = " + std::to_string(snapshot_id) +
-	                         " AND schema_name = " + QuoteLiteral(schema_name) + " LIMIT 1");
+	auto result =
+	    conn.Query("SELECT schema_id, schema_name FROM " + MetadataTable(conn, catalog_name, "ducklake_schema") +
+	               " WHERE begin_snapshot = " + std::to_string(snapshot_id) +
+	               " AND schema_name = " + QuoteLiteral(schema_name) + " LIMIT 1");
 	if (!result || result->HasError() || result->RowCount() == 0) {
 		return {duckdb::Value(), duckdb::Value(schema_name), duckdb::Value(), duckdb::Value(schema_name)};
 	}
@@ -111,7 +112,7 @@ DdlObject LookupSchemaByName(duckdb::Connection &conn, const std::string &catalo
 DdlObject LookupSchemaById(duckdb::Connection &conn, const std::string &catalog_name, int64_t snapshot_id,
                            int64_t schema_id) {
 	auto result = conn.Query(
-	    "SELECT schema_id, schema_name FROM " + MetadataTable(catalog_name, "ducklake_schema") +
+	    "SELECT schema_id, schema_name FROM " + MetadataTable(conn, catalog_name, "ducklake_schema") +
 	    " WHERE schema_id = " + std::to_string(schema_id) + " AND begin_snapshot <= " + std::to_string(snapshot_id) +
 	    " AND (end_snapshot IS NULL OR end_snapshot > " + std::to_string(snapshot_id) + ") LIMIT 1");
 	if (!result || result->HasError() || result->RowCount() == 0) {
@@ -123,8 +124,8 @@ DdlObject LookupSchemaById(duckdb::Connection &conn, const std::string &catalog_
 DdlObject LookupTableByName(duckdb::Connection &conn, const std::string &catalog_name, int64_t snapshot_id,
                             const std::string &schema_name, const std::string &table_name) {
 	auto result = conn.Query("SELECT s.schema_id, s.schema_name, t.table_id, t.table_name FROM " +
-	                         MetadataTable(catalog_name, "ducklake_table") + " t JOIN " +
-	                         MetadataTable(catalog_name, "ducklake_schema") +
+	                         MetadataTable(conn, catalog_name, "ducklake_table") + " t JOIN " +
+	                         MetadataTable(conn, catalog_name, "ducklake_schema") +
 	                         " s USING (schema_id) WHERE t.begin_snapshot = " + std::to_string(snapshot_id) +
 	                         " AND s.schema_name = " + QuoteLiteral(schema_name) +
 	                         " AND t.table_name = " + QuoteLiteral(table_name) + " LIMIT 1");
@@ -146,13 +147,14 @@ DdlObject LookupTableByName(duckdb::Connection &conn, const std::string &catalog
 //! schema row reflects its name at the right moment too.
 DdlObject LookupTableById(duckdb::Connection &conn, const std::string &catalog_name, int64_t snapshot_id,
                           int64_t table_id) {
-	auto result = conn.Query(
-	    "SELECT s.schema_id, s.schema_name, t.table_id, t.table_name FROM " +
-	    MetadataTable(catalog_name, "ducklake_table") + " t JOIN " + MetadataTable(catalog_name, "ducklake_schema") +
-	    " s USING (schema_id) WHERE t.table_id = " + std::to_string(table_id) + " AND t.begin_snapshot <= " +
-	    std::to_string(snapshot_id) + " AND (t.end_snapshot IS NULL OR t.end_snapshot > " +
-	    std::to_string(snapshot_id) + ")" + " AND s.begin_snapshot <= " + std::to_string(snapshot_id) +
-	    " AND (s.end_snapshot IS NULL OR s.end_snapshot > " + std::to_string(snapshot_id) + ") LIMIT 1");
+	auto result =
+	    conn.Query("SELECT s.schema_id, s.schema_name, t.table_id, t.table_name FROM " +
+	               MetadataTable(conn, catalog_name, "ducklake_table") + " t JOIN " +
+	               MetadataTable(conn, catalog_name, "ducklake_schema") + " s USING (schema_id) WHERE t.table_id = " +
+	               std::to_string(table_id) + " AND t.begin_snapshot <= " + std::to_string(snapshot_id) +
+	               " AND (t.end_snapshot IS NULL OR t.end_snapshot > " + std::to_string(snapshot_id) + ")" +
+	               " AND s.begin_snapshot <= " + std::to_string(snapshot_id) +
+	               " AND (s.end_snapshot IS NULL OR s.end_snapshot > " + std::to_string(snapshot_id) + ") LIMIT 1");
 	if (!result || result->HasError() || result->RowCount() == 0) {
 		return {duckdb::Value(), duckdb::Value(), duckdb::Value::BIGINT(table_id), duckdb::Value()};
 	}
@@ -162,8 +164,8 @@ DdlObject LookupTableById(duckdb::Connection &conn, const std::string &catalog_n
 DdlObject LookupViewByName(duckdb::Connection &conn, const std::string &catalog_name, int64_t snapshot_id,
                            const std::string &schema_name, const std::string &view_name) {
 	auto result = conn.Query("SELECT s.schema_id, s.schema_name, v.view_id, v.view_name FROM " +
-	                         MetadataTable(catalog_name, "ducklake_view") + " v JOIN " +
-	                         MetadataTable(catalog_name, "ducklake_schema") +
+	                         MetadataTable(conn, catalog_name, "ducklake_view") + " v JOIN " +
+	                         MetadataTable(conn, catalog_name, "ducklake_schema") +
 	                         " s USING (schema_id) WHERE v.begin_snapshot = " + std::to_string(snapshot_id) +
 	                         " AND s.schema_name = " + QuoteLiteral(schema_name) +
 	                         " AND v.view_name = " + QuoteLiteral(view_name) + " LIMIT 1");
@@ -181,13 +183,14 @@ DdlObject LookupViewByName(duckdb::Connection &conn, const std::string &catalog_
 //! `end_snapshot = drop_snap`.
 DdlObject LookupViewById(duckdb::Connection &conn, const std::string &catalog_name, int64_t snapshot_id,
                          int64_t view_id) {
-	auto result = conn.Query(
-	    "SELECT s.schema_id, s.schema_name, v.view_id, v.view_name FROM " +
-	    MetadataTable(catalog_name, "ducklake_view") + " v JOIN " + MetadataTable(catalog_name, "ducklake_schema") +
-	    " s USING (schema_id) WHERE v.view_id = " + std::to_string(view_id) + " AND v.begin_snapshot <= " +
-	    std::to_string(snapshot_id) + " AND (v.end_snapshot IS NULL OR v.end_snapshot > " +
-	    std::to_string(snapshot_id) + ")" + " AND s.begin_snapshot <= " + std::to_string(snapshot_id) +
-	    " AND (s.end_snapshot IS NULL OR s.end_snapshot > " + std::to_string(snapshot_id) + ") LIMIT 1");
+	auto result =
+	    conn.Query("SELECT s.schema_id, s.schema_name, v.view_id, v.view_name FROM " +
+	               MetadataTable(conn, catalog_name, "ducklake_view") + " v JOIN " +
+	               MetadataTable(conn, catalog_name, "ducklake_schema") + " s USING (schema_id) WHERE v.view_id = " +
+	               std::to_string(view_id) + " AND v.begin_snapshot <= " + std::to_string(snapshot_id) +
+	               " AND (v.end_snapshot IS NULL OR v.end_snapshot > " + std::to_string(snapshot_id) + ")" +
+	               " AND s.begin_snapshot <= " + std::to_string(snapshot_id) +
+	               " AND (s.end_snapshot IS NULL OR s.end_snapshot > " + std::to_string(snapshot_id) + ") LIMIT 1");
 	if (!result || result->HasError() || result->RowCount() == 0) {
 		return {duckdb::Value(), duckdb::Value(), duckdb::Value::BIGINT(view_id), duckdb::Value()};
 	}
@@ -261,7 +264,7 @@ std::vector<ColumnInfo> LookupTableColumnsAt(duckdb::Connection &conn, const std
 	auto result = conn.Query(
 	    "SELECT column_id, column_order, column_name, column_type, nulls_allowed, "
 	    "initial_default, default_value, parent_column FROM " +
-	    MetadataTable(catalog_name, "ducklake_column") + " WHERE table_id = " + std::to_string(table_id) +
+	    MetadataTable(conn, catalog_name, "ducklake_column") + " WHERE table_id = " + std::to_string(table_id) +
 	    " AND begin_snapshot <= " + std::to_string(snapshot_id) + " AND (end_snapshot IS NULL OR end_snapshot > " +
 	    std::to_string(snapshot_id) + ")" + " ORDER BY column_order ASC");
 	if (!result || result->HasError()) {
@@ -578,7 +581,7 @@ std::string DiffsToJson(std::vector<ColumnDiff> diffs) {
 //! `altered.table` with a rename payload rather than as `created.table`.
 duckdb::Value PreviousTableName(duckdb::Connection &conn, const std::string &catalog_name, int64_t table_id,
                                 int64_t snapshot_id) {
-	auto result = conn.Query("SELECT table_name FROM " + MetadataTable(catalog_name, "ducklake_table") +
+	auto result = conn.Query("SELECT table_name FROM " + MetadataTable(conn, catalog_name, "ducklake_table") +
 	                         " WHERE table_id = " + std::to_string(table_id) + " AND begin_snapshot < " +
 	                         std::to_string(snapshot_id) + " ORDER BY begin_snapshot DESC LIMIT 1");
 	if (!result || result->HasError() || result->RowCount() == 0) {
@@ -599,7 +602,7 @@ ViewInfo LookupViewMetadata(duckdb::Connection &conn, const std::string &catalog
                             int64_t snapshot_id) {
 	ViewInfo info;
 	auto result = conn.Query(
-	    "SELECT sql, dialect, column_aliases FROM " + MetadataTable(catalog_name, "ducklake_view") +
+	    "SELECT sql, dialect, column_aliases FROM " + MetadataTable(conn, catalog_name, "ducklake_view") +
 	    " WHERE view_id = " + std::to_string(view_id) + " AND begin_snapshot <= " + std::to_string(snapshot_id) +
 	    " AND (end_snapshot IS NULL OR end_snapshot > " + std::to_string(snapshot_id) + ") LIMIT 1");
 	if (!result || result->HasError() || result->RowCount() == 0) {
@@ -645,7 +648,7 @@ std::string BuildCreatedTableDetails(duckdb::Connection &conn, const std::string
 //! skip them and let downstream serialise the empty diff group.
 bool TableSchemaVersionBumpedAt(duckdb::Connection &conn, const std::string &catalog_name, int64_t table_id,
                                 int64_t snapshot_id) {
-	auto result = conn.Query("SELECT 1 FROM " + MetadataTable(catalog_name, "ducklake_schema_versions") +
+	auto result = conn.Query("SELECT 1 FROM " + MetadataTable(conn, catalog_name, "ducklake_schema_versions") +
 	                         " WHERE table_id = " + std::to_string(table_id) +
 	                         " AND begin_snapshot = " + std::to_string(snapshot_id) + " LIMIT 1");
 	if (!result || result->HasError()) {
@@ -1211,8 +1214,8 @@ void AppendDdlTickRows(duckdb::Connection &conn, const std::string &catalog_name
                        std::vector<std::vector<duckdb::Value>> &out, bool stateful) {
 	auto snapshots =
 	    conn.Query(std::string("SELECT s.snapshot_id, s.snapshot_time, s.schema_version, c.changes_made FROM ") +
-	               MetadataTable(catalog_name, "ducklake_snapshot") + " s JOIN " +
-	               MetadataTable(catalog_name, "ducklake_snapshot_changes") +
+	               MetadataTable(conn, catalog_name, "ducklake_snapshot") + " s JOIN " +
+	               MetadataTable(conn, catalog_name, "ducklake_snapshot_changes") +
 	               " c USING (snapshot_id) WHERE s.snapshot_id BETWEEN " + std::to_string(start_snapshot) + " AND " +
 	               std::to_string(end_snapshot) + " ORDER BY s.snapshot_id ASC");
 	if (!snapshots || snapshots->HasError()) {
@@ -1394,8 +1397,8 @@ void ValidateDdlRangeBounds(duckdb::Connection &conn, const std::string &catalog
 	if (to_snapshot < from_snapshot) {
 		throw duckdb::InvalidInputException("cdc_ddl_changes_query: from_snapshot must be <= to_snapshot");
 	}
-	auto oldest_result =
-	    conn.Query("SELECT COALESCE(min(snapshot_id), 0) FROM " + MetadataTable(catalog_name, "ducklake_snapshot"));
+	auto oldest_result = conn.Query("SELECT COALESCE(min(snapshot_id), 0) FROM " +
+	                                MetadataTable(conn, catalog_name, "ducklake_snapshot"));
 	const auto oldest_snapshot = SingleInt64(*oldest_result, "oldest available snapshot");
 	if (from_snapshot < oldest_snapshot) {
 		throw duckdb::InvalidInputException(
@@ -1440,7 +1443,7 @@ std::vector<int64_t> DdlInt64ListNamedParameter(duckdb::TableFunctionBindInput &
 
 int64_t ResolveDdlSchemaName(duckdb::Connection &conn, const std::string &catalog_name, const std::string &schema_name,
                              int64_t snapshot_id) {
-	auto rows = conn.Query("SELECT schema_id FROM " + MetadataTable(catalog_name, "ducklake_schema") +
+	auto rows = conn.Query("SELECT schema_id FROM " + MetadataTable(conn, catalog_name, "ducklake_schema") +
 	                       " WHERE schema_name = " + QuoteLiteral(schema_name) + " AND begin_snapshot <= " +
 	                       std::to_string(snapshot_id) + " AND (end_snapshot IS NULL OR end_snapshot > " +
 	                       std::to_string(snapshot_id) + ") ORDER BY schema_id DESC LIMIT 1");
@@ -1659,8 +1662,8 @@ std::unordered_set<int64_t> ResolveTableIdsForFilter(duckdb::Connection &conn, c
 	}
 	const auto schema_name = qualified_name.substr(0, dot);
 	const auto table_name = qualified_name.substr(dot + 1);
-	auto result = conn.Query("SELECT DISTINCT t.table_id FROM " + MetadataTable(catalog_name, "ducklake_table") +
-	                         " t JOIN " + MetadataTable(catalog_name, "ducklake_schema") +
+	auto result = conn.Query("SELECT DISTINCT t.table_id FROM " + MetadataTable(conn, catalog_name, "ducklake_table") +
+	                         " t JOIN " + MetadataTable(conn, catalog_name, "ducklake_schema") +
 	                         " s USING (schema_id) WHERE s.schema_name = " + QuoteLiteral(schema_name) +
 	                         " AND t.table_name = " + QuoteLiteral(table_name) +
 	                         " AND t.begin_snapshot <= " + std::to_string(to_snapshot) +

--- a/src/dml.cpp
+++ b/src/dml.cpp
@@ -278,8 +278,8 @@ void AppendDmlTickRows(duckdb::Connection &conn, const std::string &catalog_name
                        std::vector<std::vector<duckdb::Value>> &out, bool stateful) {
 	auto rows =
 	    conn.Query(std::string("SELECT s.snapshot_id, s.snapshot_time, s.schema_version, c.changes_made FROM ") +
-	               MetadataTable(catalog_name, "ducklake_snapshot") + " s JOIN " +
-	               MetadataTable(catalog_name, "ducklake_snapshot_changes") +
+	               MetadataTable(conn, catalog_name, "ducklake_snapshot") + " s JOIN " +
+	               MetadataTable(conn, catalog_name, "ducklake_snapshot_changes") +
 	               " c USING (snapshot_id) WHERE s.snapshot_id BETWEEN " + std::to_string(start_snapshot) + " AND " +
 	               std::to_string(end_snapshot) + " ORDER BY s.snapshot_id ASC");
 	if (!rows || rows->HasError()) {
@@ -936,8 +936,8 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcChangesInit(duckdb::Clie
 		where_clause << ")";
 	}
 
-	const auto snapshot_table = MetadataTable(data.catalog_name, "ducklake_snapshot");
-	const auto changes_table = MetadataTable(data.catalog_name, "ducklake_snapshot_changes");
+	const auto snapshot_table = MetadataTable(conn, data.catalog_name, "ducklake_snapshot");
+	const auto changes_table = MetadataTable(conn, data.catalog_name, "ducklake_snapshot_changes");
 	const auto cache_key = DmlSegmentCacheKey(MetadataAttachmentCacheKey(conn, data.catalog_name), data,
 	                                          scan_table_name, start_snapshot, end_snapshot);
 	bool build_segment = false;
@@ -1032,8 +1032,8 @@ void ValidateRangeBounds(duckdb::Connection &conn, const std::string &catalog_na
 	if (to_snapshot < from_snapshot) {
 		throw duckdb::InvalidInputException("%s: from_snapshot must be <= to_snapshot", feature_name);
 	}
-	auto oldest_result =
-	    conn.Query("SELECT COALESCE(min(snapshot_id), 0) FROM " + MetadataTable(catalog_name, "ducklake_snapshot"));
+	auto oldest_result = conn.Query("SELECT COALESCE(min(snapshot_id), 0) FROM " +
+	                                MetadataTable(conn, catalog_name, "ducklake_snapshot"));
 	const auto oldest_snapshot = SingleInt64(*oldest_result, "oldest available snapshot");
 	if (from_snapshot < oldest_snapshot) {
 		throw duckdb::InvalidInputException("%s: from_snapshot %lld is older than oldest available snapshot %lld",
@@ -1210,9 +1210,9 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcRangeChangesInit(duckdb:
 		auto query = std::string("SELECT ") + column_list.str() +
 		             ", s.snapshot_time, c.author, c.commit_message, c.commit_extra_info FROM " +
 		             DuckLakeTableChangesCall(data.catalog_name, data.table_name, from_snapshot, data.to_snapshot) +
-		             " tc LEFT JOIN " + MetadataTable(data.catalog_name, "ducklake_snapshot") +
+		             " tc LEFT JOIN " + MetadataTable(conn, data.catalog_name, "ducklake_snapshot") +
 		             " s ON s.snapshot_id = tc.snapshot_id LEFT JOIN " +
-		             MetadataTable(data.catalog_name, "ducklake_snapshot_changes") +
+		             MetadataTable(conn, data.catalog_name, "ducklake_snapshot_changes") +
 		             " c ON c.snapshot_id = tc.snapshot_id ORDER BY tc.snapshot_id ASC, tc.rowid ASC";
 		return conn.Query(query);
 	};
@@ -1223,7 +1223,7 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcRangeChangesInit(duckdb:
 	}
 	if (rows->RowCount() == 0 && data.allow_history_fallback) {
 		auto begin_result = conn.Query("SELECT COALESCE(min(begin_snapshot), " + std::to_string(data.from_snapshot) +
-		                               ") FROM " + MetadataTable(data.catalog_name, "ducklake_table") +
+		                               ") FROM " + MetadataTable(conn, data.catalog_name, "ducklake_table") +
 		                               " WHERE table_id = " + std::to_string(data.table_id));
 		if (begin_result && !begin_result->HasError() && begin_result->RowCount() > 0 &&
 		    !begin_result->GetValue(0, 0).IsNull()) {

--- a/src/ducklake_metadata.cpp
+++ b/src/ducklake_metadata.cpp
@@ -19,8 +19,11 @@
 #include "duckdb/parser/keyword_helper.hpp"
 
 #include <cctype>
+#include <chrono>
 #include <mutex>
 #include <sstream>
+#include <thread>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace duckdb_cdc {
@@ -194,6 +197,15 @@ std::string MetadataTable(const std::string &catalog_name, const std::string &ta
 	return MetadataDatabase(catalog_name) + "." + QuoteIdentifier(table_name);
 }
 
+std::string MetadataTable(duckdb::Connection &conn, const std::string &catalog_name, const std::string &table_name) {
+	const auto state = ResolveCdcCatalogState(conn, catalog_name);
+	if (state.metadata_schema == "public") {
+		return MetadataTable(catalog_name, table_name);
+	}
+	return MetadataDatabase(catalog_name) + "." + QuoteIdentifier(state.metadata_schema) + "." +
+	       QuoteIdentifier(table_name);
+}
+
 std::string MetadataAttachmentCacheKey(duckdb::Connection &conn, const std::string &catalog_name) {
 	const auto metadata_database = "__ducklake_metadata_" + catalog_name;
 	auto result = conn.Query("SELECT database_oid, type, path FROM duckdb_databases() WHERE database_name = " +
@@ -215,11 +227,95 @@ std::string MetadataAttachmentCacheKey(duckdb::Connection &conn, const std::stri
 	return catalog_name + "|" + oid + "|" + type + "|" + path;
 }
 
+namespace {
+
+std::mutex CDC_CATALOG_CONFIG_MUTEX;
+std::unordered_map<std::string, CdcCatalogState> CDC_CATALOG_CONFIGS;
+std::unordered_set<std::string> CONFIGURED_CATALOG_NAMES;
+std::unordered_set<std::string> ACTIVE_CDC_CATALOGS;
+
+void ValidateSchemaName(const std::string &value, const std::string &argument_name) {
+	if (value.empty()) {
+		throw duckdb::InvalidInputException("cdc_configure: %s cannot be empty", argument_name);
+	}
+	if (value.size() > 63) {
+		throw duckdb::InvalidInputException("cdc_configure: %s must be at most 63 bytes", argument_name);
+	}
+	if (value.find('\0') != std::string::npos) {
+		throw duckdb::InvalidInputException("cdc_configure: %s cannot contain a NUL byte", argument_name);
+	}
+}
+
+std::string CatalogConfigKey(duckdb::Connection &conn, const std::string &catalog_name) {
+	const auto key = MetadataAttachmentCacheKey(conn, catalog_name);
+	if (key.empty()) {
+		throw duckdb::InvalidInputException("cdc_configure: unable to resolve DuckLake catalog '%s'", catalog_name);
+	}
+	return key;
+}
+
+std::string StateSchemaCacheKey(duckdb::Connection &conn, const std::string &catalog_name,
+                                const std::string &state_schema) {
+	return MetadataAttachmentCacheKey(conn, catalog_name) + "|state_schema=" + state_schema;
+}
+
+} // namespace
+
+CdcCatalogState ResolveCdcCatalogState(duckdb::Connection &conn, const std::string &catalog_name) {
+	{
+		std::lock_guard<std::mutex> guard(CDC_CATALOG_CONFIG_MUTEX);
+		if (CONFIGURED_CATALOG_NAMES.count(catalog_name) == 0) {
+			return {catalog_name, "", "public", STATE_SCHEMA};
+		}
+	}
+	const auto attachment_identity = MetadataAttachmentCacheKey(conn, catalog_name);
+	if (!attachment_identity.empty()) {
+		std::lock_guard<std::mutex> guard(CDC_CATALOG_CONFIG_MUTEX);
+		auto entry = CDC_CATALOG_CONFIGS.find(attachment_identity);
+		if (entry != CDC_CATALOG_CONFIGS.end()) {
+			return entry->second;
+		}
+	}
+	return {catalog_name, attachment_identity, "public", STATE_SCHEMA};
+}
+
+CdcCatalogState ConfigureCdcCatalogState(duckdb::Connection &conn, const std::string &catalog_name,
+                                         const std::string &state_schema, const std::string &metadata_schema) {
+	ValidateSchemaName(state_schema, "state_schema");
+	ValidateSchemaName(metadata_schema, "metadata_schema");
+	const auto key = CatalogConfigKey(conn, catalog_name);
+	CdcCatalogState requested {catalog_name, key, metadata_schema, state_schema};
+	std::lock_guard<std::mutex> guard(CDC_CATALOG_CONFIG_MUTEX);
+	auto existing = CDC_CATALOG_CONFIGS.find(key);
+	if (existing != CDC_CATALOG_CONFIGS.end()) {
+		if (existing->second.state_schema == state_schema && existing->second.metadata_schema == metadata_schema) {
+			return existing->second;
+		}
+		throw duckdb::InvalidInputException(
+		    "cdc_configure: catalog '%s' is already configured with state_schema '%s' and metadata_schema '%s'",
+		    catalog_name, existing->second.state_schema, existing->second.metadata_schema);
+	}
+	if (ACTIVE_CDC_CATALOGS.count(key) > 0) {
+		throw duckdb::InvalidInputException(
+		    "cdc_configure: catalog '%s' has already initialized CDC state; configure it before the first stateful "
+		    "cdc_* call",
+		    catalog_name);
+	}
+	CDC_CATALOG_CONFIGS.emplace(key, requested);
+	CONFIGURED_CATALOG_NAMES.insert(catalog_name);
+	return requested;
+}
+
 std::string StateTable(const std::string &catalog_name, const std::string &table_name, bool use_state_schema) {
 	if (use_state_schema) {
 		return MetadataDatabase(catalog_name) + "." + QuoteIdentifier(STATE_SCHEMA) + "." + QuoteIdentifier(table_name);
 	}
 	return MetadataDatabase(catalog_name) + ".main." + QuoteIdentifier(table_name);
+}
+
+std::string StateTable(const std::string &catalog_name, const std::string &table_name,
+                       const std::string &state_schema) {
+	return MetadataDatabase(catalog_name) + "." + QuoteIdentifier(state_schema) + "." + QuoteIdentifier(table_name);
 }
 
 namespace {
@@ -258,21 +354,21 @@ void StateSchemaCacheRemember(const std::string &cache_key) {
 	STATE_SCHEMA_CACHE.insert(cache_key);
 }
 
-bool ProbeStateSchema(duckdb::Connection &conn, const std::string &catalog_name) {
+bool ProbeStateSchema(duckdb::Connection &conn, const std::string &catalog_name, const std::string &state_schema) {
 	// Probe the state table directly before consulting DuckDB's catalog
 	// enumeration views. DuckDB v1.5.4 no longer consistently exposes schemas
 	// belonging to DuckLake's hidden metadata attachment through
 	// duckdb_schemas()/duckdb_tables() on a fresh internal connection, even
 	// though fully-qualified access to the table works. The direct zero-row
 	// query is both cheaper and authoritative for the fact we need here.
-	auto direct = conn.Query("SELECT 1 FROM " + StateTable(catalog_name, CONSUMERS_TABLE, true) + " LIMIT 0");
+	auto direct = conn.Query("SELECT 1 FROM " + StateTable(catalog_name, CONSUMERS_TABLE, state_schema) + " LIMIT 0");
 	if (direct && !direct->HasError()) {
 		return true;
 	}
 
 	const auto md_db = QuoteLiteral("__ducklake_metadata_" + catalog_name);
 	auto schemas = conn.Query("SELECT count(*) FROM duckdb_schemas() WHERE database_name = " + md_db +
-	                          " AND schema_name = " + QuoteLiteral(STATE_SCHEMA));
+	                          " AND schema_name = " + QuoteLiteral(state_schema));
 	if (schemas && !schemas->HasError() && schemas->RowCount() > 0 && !schemas->GetValue(0, 0).IsNull() &&
 	    schemas->GetValue(0, 0).GetValue<int64_t>() > 0) {
 		return true;
@@ -280,7 +376,7 @@ bool ProbeStateSchema(duckdb::Connection &conn, const std::string &catalog_name)
 	// `duckdb_schemas()` did not see it. Try the table-level enumeration
 	// for the consumers table that bootstrap always creates.
 	auto tables = conn.Query("SELECT count(*) FROM duckdb_tables() WHERE database_name = " + md_db +
-	                         " AND schema_name = " + QuoteLiteral(STATE_SCHEMA) +
+	                         " AND schema_name = " + QuoteLiteral(state_schema) +
 	                         " AND table_name = " + QuoteLiteral(CONSUMERS_TABLE));
 	return tables && !tables->HasError() && tables->RowCount() > 0 && !tables->GetValue(0, 0).IsNull() &&
 	       tables->GetValue(0, 0).GetValue<int64_t>() > 0;
@@ -289,11 +385,12 @@ bool ProbeStateSchema(duckdb::Connection &conn, const std::string &catalog_name)
 } // namespace
 
 bool StateSchemaExists(duckdb::Connection &conn, const std::string &catalog_name) {
-	const auto cache_key = MetadataAttachmentCacheKey(conn, catalog_name);
+	const auto state = ResolveCdcCatalogState(conn, catalog_name);
+	const auto cache_key = StateSchemaCacheKey(conn, catalog_name, state.state_schema);
 	if (StateSchemaCacheLookup(cache_key)) {
 		return true;
 	}
-	if (ProbeStateSchema(conn, catalog_name)) {
+	if (ProbeStateSchema(conn, catalog_name, state.state_schema)) {
 		StateSchemaCacheRemember(cache_key);
 		return true;
 	}
@@ -301,7 +398,10 @@ bool StateSchemaExists(duckdb::Connection &conn, const std::string &catalog_name
 }
 
 std::string StateTable(duckdb::Connection &conn, const std::string &catalog_name, const std::string &table_name) {
-	return StateTable(catalog_name, table_name, StateSchemaExists(conn, catalog_name));
+	if (!StateSchemaExists(conn, catalog_name)) {
+		return StateTable(catalog_name, table_name, false);
+	}
+	return StateTable(catalog_name, table_name, ResolveCdcCatalogState(conn, catalog_name).state_schema);
 }
 
 //===--------------------------------------------------------------------===//
@@ -310,7 +410,7 @@ std::string StateTable(duckdb::Connection &conn, const std::string &catalog_name
 
 int64_t ResolveSnapshot(duckdb::Connection &conn, const std::string &catalog_name, const std::string &literal,
                         const std::string &argument_name, const std::string &feature_name, bool null_means_oldest) {
-	const auto snapshot_table = MetadataTable(catalog_name, "ducklake_snapshot");
+	const auto snapshot_table = MetadataTable(conn, catalog_name, "ducklake_snapshot");
 	const auto lower_literal = duckdb::StringUtil::Lower(literal);
 	if (literal.empty() && null_means_oldest) {
 		auto result = conn.Query("SELECT min(snapshot_id) FROM " + snapshot_table);
@@ -350,7 +450,7 @@ int64_t ResolveResetSnapshot(duckdb::Connection &conn, const std::string &catalo
 }
 
 int64_t ResolveSchemaVersion(duckdb::Connection &conn, const std::string &catalog_name, int64_t snapshot_id) {
-	const auto snapshot_table = MetadataTable(catalog_name, "ducklake_snapshot");
+	const auto snapshot_table = MetadataTable(conn, catalog_name, "ducklake_snapshot");
 	auto result = conn.Query("SELECT schema_version FROM " + snapshot_table +
 	                         " WHERE snapshot_id = " + std::to_string(snapshot_id) + " LIMIT 1");
 	return SingleInt64(*result, "schema_version");
@@ -358,16 +458,18 @@ int64_t ResolveSchemaVersion(duckdb::Connection &conn, const std::string &catalo
 
 int64_t CurrentSnapshot(duckdb::Connection &conn, const std::string &catalog_name) {
 	if (MetadataBackendIsPostgres(conn, catalog_name)) {
-		auto result = QueryPostgresMetadata(
-		    conn, catalog_name, "SELECT max(snapshot_id) AS current_snapshot FROM public.ducklake_snapshot");
+		const auto metadata_schema = ResolveCdcCatalogState(conn, catalog_name).metadata_schema;
+		auto result = QueryPostgresMetadata(conn, catalog_name,
+		                                    "SELECT max(snapshot_id) AS current_snapshot FROM " +
+		                                        QuoteIdentifier(metadata_schema) + ".ducklake_snapshot");
 		return SingleInt64(*result, "current snapshot");
 	}
-	auto result = conn.Query("SELECT max(snapshot_id) FROM " + MetadataTable(catalog_name, "ducklake_snapshot"));
+	auto result = conn.Query("SELECT max(snapshot_id) FROM " + MetadataTable(conn, catalog_name, "ducklake_snapshot"));
 	return SingleInt64(*result, "current snapshot");
 }
 
 duckdb::Value SnapshotTime(duckdb::Connection &conn, const std::string &catalog_name, int64_t snapshot_id) {
-	auto result = conn.Query("SELECT snapshot_time FROM " + MetadataTable(catalog_name, "ducklake_snapshot") +
+	auto result = conn.Query("SELECT snapshot_time FROM " + MetadataTable(conn, catalog_name, "ducklake_snapshot") +
 	                         " WHERE snapshot_id = " + std::to_string(snapshot_id));
 	if (!result || result->HasError() || result->RowCount() == 0) {
 		return duckdb::Value();
@@ -377,9 +479,10 @@ duckdb::Value SnapshotTime(duckdb::Connection &conn, const std::string &catalog_
 
 int64_t FirstSnapshotAfter(duckdb::Connection &conn, const std::string &catalog_name, int64_t last_snapshot,
                            int64_t current_snapshot) {
-	auto result = conn.Query("SELECT snapshot_id FROM " + MetadataTable(catalog_name, "ducklake_snapshot_changes") +
-	                         " WHERE snapshot_id > " + std::to_string(last_snapshot) +
-	                         " AND snapshot_id <= " + std::to_string(current_snapshot) + " ORDER BY snapshot_id ASC");
+	auto result =
+	    conn.Query("SELECT snapshot_id FROM " + MetadataTable(conn, catalog_name, "ducklake_snapshot_changes") +
+	               " WHERE snapshot_id > " + std::to_string(last_snapshot) +
+	               " AND snapshot_id <= " + std::to_string(current_snapshot) + " ORDER BY snapshot_id ASC");
 	if (!result || result->HasError()) {
 		return -1;
 	}
@@ -394,7 +497,7 @@ int64_t FirstSnapshotAfter(duckdb::Connection &conn, const std::string &catalog_
 
 void EnsureSnapshotExistsOrGap(duckdb::Connection &conn, const std::string &catalog_name,
                                const std::string &consumer_name, int64_t snapshot_id) {
-	const auto snapshot_table = MetadataTable(catalog_name, "ducklake_snapshot");
+	const auto snapshot_table = MetadataTable(conn, catalog_name, "ducklake_snapshot");
 	auto exists =
 	    conn.Query("SELECT count(*) FROM " + snapshot_table + " WHERE snapshot_id = " + std::to_string(snapshot_id));
 	if (SingleInt64(*exists, "snapshot existence") > 0) {
@@ -447,8 +550,9 @@ bool SnapshotHasSchemaChange(const std::string &changes_made) {
 //! `NextExternalSchemaChangeSnapshot` returns -1, since it searches
 //! strictly AFTER start).
 bool SnapshotIsExternalSchemaChange(duckdb::Connection &conn, const std::string &catalog_name, int64_t snapshot_id) {
-	auto result = conn.Query("SELECT changes_made FROM " + MetadataTable(catalog_name, "ducklake_snapshot_changes") +
-	                         " WHERE snapshot_id = " + std::to_string(snapshot_id));
+	auto result =
+	    conn.Query("SELECT changes_made FROM " + MetadataTable(conn, catalog_name, "ducklake_snapshot_changes") +
+	               " WHERE snapshot_id = " + std::to_string(snapshot_id));
 	if (!result || result->HasError() || result->RowCount() == 0) {
 		return false;
 	}
@@ -475,10 +579,10 @@ int64_t NextExternalSchemaChangeSnapshot(duckdb::Connection &conn, const std::st
 	// about to read the ALTER), the window's schema_version is the
 	// post-change version (set by ResolveSchemaVersion(start) in the
 	// caller); bounding the window at `start - 1` here would be wrong.
-	auto result =
-	    conn.Query("SELECT snapshot_id, changes_made FROM " + MetadataTable(catalog_name, "ducklake_snapshot_changes") +
-	               " WHERE snapshot_id > " + std::to_string(start_snapshot) +
-	               " AND snapshot_id <= " + std::to_string(current_snapshot) + " ORDER BY snapshot_id ASC");
+	auto result = conn.Query("SELECT snapshot_id, changes_made FROM " +
+	                         MetadataTable(conn, catalog_name, "ducklake_snapshot_changes") + " WHERE snapshot_id > " +
+	                         std::to_string(start_snapshot) +
+	                         " AND snapshot_id <= " + std::to_string(current_snapshot) + " ORDER BY snapshot_id ASC");
 	if (!result || result->HasError()) {
 		return -1;
 	}
@@ -518,9 +622,9 @@ int64_t ResolveSinceStartSnapshot(duckdb::Connection &conn, const std::string &c
 	// Epoch math instead of `now() - INTERVAL X SECOND`: DuckDB has no
 	// `-(TIMESTAMP_TZ, INTERVAL)` binder, but `epoch(...)` works on any
 	// timestamp variant and the comparison is straight DOUBLE arithmetic.
-	auto result =
-	    conn.Query("SELECT COALESCE(max(snapshot_id), 0) FROM " + MetadataTable(catalog_name, "ducklake_snapshot") +
-	               " WHERE epoch(snapshot_time) <= epoch(now()) - " + std::to_string(since_seconds));
+	auto result = conn.Query("SELECT COALESCE(max(snapshot_id), 0) FROM " +
+	                         MetadataTable(conn, catalog_name, "ducklake_snapshot") +
+	                         " WHERE epoch(snapshot_time) <= epoch(now()) - " + std::to_string(since_seconds));
 	return SingleInt64(*result, "since_seconds start snapshot");
 }
 
@@ -528,13 +632,15 @@ int64_t ResolveSinceStartSnapshot(duckdb::Connection &conn, const std::string &c
 // State-table DDL strings + lazy bootstrap
 //===--------------------------------------------------------------------===//
 
-std::string ConsumersDdl(const std::string &catalog_name, bool use_state_schema) {
+std::string ConsumersDdl(const std::string &catalog_name, bool use_state_schema, const std::string &state_schema) {
 	// `table_id` is the single subscribed table for DML consumers (one
 	// DML consumer = one table, by contract). It is NULL for DDL
 	// consumers — DDL consumers can subscribe to schemas, tables, or the
 	// whole catalog and route those facts through
 	// `__ducklake_cdc_consumer_subscriptions`.
-	return "CREATE TABLE IF NOT EXISTS " + StateTable(catalog_name, CONSUMERS_TABLE, use_state_schema) +
+	const auto table = use_state_schema ? StateTable(catalog_name, CONSUMERS_TABLE, state_schema)
+	                                    : StateTable(catalog_name, CONSUMERS_TABLE, false);
+	return "CREATE TABLE IF NOT EXISTS " + table +
 	       " ("
 	       "consumer_name VARCHAR, "
 	       "consumer_kind VARCHAR NOT NULL, "
@@ -553,8 +659,11 @@ std::string ConsumersDdl(const std::string &catalog_name, bool use_state_schema)
 	       ")";
 }
 
-std::string ConsumerSubscriptionsDdl(const std::string &catalog_name, bool use_state_schema) {
-	return "CREATE TABLE IF NOT EXISTS " + StateTable(catalog_name, CONSUMER_SUBSCRIPTIONS_TABLE, use_state_schema) +
+std::string ConsumerSubscriptionsDdl(const std::string &catalog_name, bool use_state_schema,
+                                     const std::string &state_schema) {
+	const auto table = use_state_schema ? StateTable(catalog_name, CONSUMER_SUBSCRIPTIONS_TABLE, state_schema)
+	                                    : StateTable(catalog_name, CONSUMER_SUBSCRIPTIONS_TABLE, false);
+	return "CREATE TABLE IF NOT EXISTS " + table +
 	       " ("
 	       "consumer_id BIGINT NOT NULL, "
 	       "subscription_id BIGINT NOT NULL, "
@@ -569,8 +678,10 @@ std::string ConsumerSubscriptionsDdl(const std::string &catalog_name, bool use_s
 	       ")";
 }
 
-std::string AuditDdl(const std::string &catalog_name, bool use_state_schema) {
-	return "CREATE TABLE IF NOT EXISTS " + StateTable(catalog_name, AUDIT_TABLE, use_state_schema) +
+std::string AuditDdl(const std::string &catalog_name, bool use_state_schema, const std::string &state_schema) {
+	const auto table = use_state_schema ? StateTable(catalog_name, AUDIT_TABLE, state_schema)
+	                                    : StateTable(catalog_name, AUDIT_TABLE, false);
+	return "CREATE TABLE IF NOT EXISTS " + table +
 	       " ("
 	       "audit_id BIGINT, "
 	       "ts TIMESTAMP WITH TIME ZONE NOT NULL, "
@@ -582,9 +693,10 @@ std::string AuditDdl(const std::string &catalog_name, bool use_state_schema) {
 	       ")";
 }
 
-std::string SnapshotNotifyChannel(const std::string &catalog_name) {
+std::string SnapshotNotifyChannel(duckdb::Connection &conn, const std::string &catalog_name) {
+	const auto state = ResolveCdcCatalogState(conn, catalog_name);
 	std::string out = "ducklake_cdc_snapshot_";
-	for (auto c : catalog_name) {
+	for (auto c : state.state_schema) {
 		if (out.size() >= 63) {
 			break;
 		}
@@ -658,21 +770,26 @@ void InstallPostgresSnapshotNotifyBestEffort(duckdb::Connection &conn, const std
 	if (!MetadataBackendIsPostgres(conn, catalog_name)) {
 		return;
 	}
-	const auto channel = SnapshotNotifyChannel(catalog_name);
-	PostgresExecuteBestEffort(conn, catalog_name, "CREATE SCHEMA IF NOT EXISTS " + QuoteIdentifier(STATE_SCHEMA));
+	const auto state = ResolveCdcCatalogState(conn, catalog_name);
+	const auto channel = SnapshotNotifyChannel(conn, catalog_name);
+	const auto state_schema = QuoteIdentifier(state.state_schema);
+	const auto snapshot_table = QuoteIdentifier(state.metadata_schema) + "." + QuoteIdentifier("ducklake_snapshot");
+	PostgresExecuteBestEffort(conn, catalog_name, "CREATE SCHEMA IF NOT EXISTS " + state_schema);
 	PostgresExecuteBestEffort(
 	    conn, catalog_name,
-	    "CREATE OR REPLACE FUNCTION " + QuoteIdentifier(STATE_SCHEMA) +
+	    "CREATE OR REPLACE FUNCTION " + state_schema +
 	        ".ducklake_cdc_notify_snapshot() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN PERFORM pg_notify(" +
 	        QuoteLiteral(channel) + ", NEW.snapshot_id::text); RETURN NEW; END; $$");
-	PostgresExecuteBestEffort(
-	    conn, catalog_name,
-	    "DO $$ BEGIN IF NOT EXISTS ("
-	    "SELECT 1 FROM pg_trigger WHERE tgname = 'ducklake_cdc_snapshot_notify' "
-	    "AND tgrelid = 'public.ducklake_snapshot'::regclass"
-	    ") THEN EXECUTE 'CREATE TRIGGER ducklake_cdc_snapshot_notify AFTER INSERT ON public.ducklake_snapshot "
-	    "FOR EACH ROW EXECUTE FUNCTION " +
-	        QuoteIdentifier(STATE_SCHEMA) + ".ducklake_cdc_notify_snapshot()'; END IF; END $$");
+	const auto create_trigger = "CREATE TRIGGER ducklake_cdc_snapshot_notify AFTER INSERT ON " + snapshot_table +
+	                            " FOR EACH ROW EXECUTE FUNCTION " + state_schema + ".ducklake_cdc_notify_snapshot()";
+	PostgresExecuteBestEffort(conn, catalog_name,
+	                          "DO $$ BEGIN IF NOT EXISTS ("
+	                          "SELECT 1 FROM pg_trigger WHERE tgname = 'ducklake_cdc_snapshot_notify' "
+	                          "AND tgrelid = " +
+	                              QuoteLiteral(snapshot_table) +
+	                              "::regclass"
+	                              ") THEN EXECUTE " +
+	                              QuoteLiteral(create_trigger) + "; END IF; END $$");
 }
 
 void BootstrapConsumerStateOrThrow(duckdb::Connection &conn, const std::string &catalog_name) {
@@ -685,41 +802,62 @@ void BootstrapConsumerStateOrThrow(duckdb::Connection &conn, const std::string &
 	// installation from several outer ClientContexts can trip DuckDB/DuckLake's
 	// outer-to-inner catalog lock handoff (H-022). The authoritative zero-row
 	// state-table probe is sufficient once bootstrap has completed.
-	if (ProbeStateSchema(conn, catalog_name)) {
-		StateSchemaCacheRemember(MetadataAttachmentCacheKey(conn, catalog_name));
+	auto state = ResolveCdcCatalogState(conn, catalog_name);
+	if (state.attachment_identity.empty()) {
+		state.attachment_identity = MetadataAttachmentCacheKey(conn, catalog_name);
+	}
+	{
+		std::lock_guard<std::mutex> guard(CDC_CATALOG_CONFIG_MUTEX);
+		if (!state.attachment_identity.empty()) {
+			ACTIVE_CDC_CATALOGS.insert(state.attachment_identity);
+		}
+	}
+	const auto cache_key = StateSchemaCacheKey(conn, catalog_name, state.state_schema);
+	if (ProbeStateSchema(conn, catalog_name, state.state_schema)) {
+		StateSchemaCacheRemember(cache_key);
 		return;
 	}
 
 	// Only one connection in this process may perform first bootstrap. Recheck
 	// after taking the lock because another caller may have completed while we
-	// waited. Cross-process first bootstrap still relies on backend DDL
-	// idempotence and is documented separately under H-022.
+	// waited. PostgreSQL first bootstrap also retries: CREATE SCHEMA IF NOT
+	// EXISTS can still race another uncommitted CREATE from a different process.
 	std::lock_guard<std::mutex> bootstrap_guard(STATE_BOOTSTRAP_MUTEX);
-	if (ProbeStateSchema(conn, catalog_name)) {
-		StateSchemaCacheRemember(MetadataAttachmentCacheKey(conn, catalog_name));
-		return;
-	}
-	ExecuteChecked(conn, "BEGIN TRANSACTION");
-	try {
-		auto create_schema = conn.Query("CREATE SCHEMA IF NOT EXISTS " + MetadataDatabase(catalog_name) + "." +
-		                                QuoteIdentifier(STATE_SCHEMA));
-		const bool use_state_schema = create_schema && !create_schema->HasError();
-		ExecuteChecked(conn, ConsumersDdl(catalog_name, use_state_schema));
-		ExecuteChecked(conn, ConsumerSubscriptionsDdl(catalog_name, use_state_schema));
-		ExecuteChecked(conn, AuditDdl(catalog_name, use_state_schema));
-		InstallPostgresSnapshotNotifyBestEffort(conn, catalog_name);
-		ExecuteChecked(conn, "COMMIT");
-		if (use_state_schema) {
-			// Pre-warm the StateSchemaExists cache only after the DDL is
-			// committed and visible to other DatabaseInstance connections.
-			StateSchemaCacheRemember(MetadataAttachmentCacheKey(conn, catalog_name));
+	const bool postgres = MetadataBackendIsPostgres(conn, catalog_name);
+	for (int attempt = 0; attempt < (postgres ? 10 : 1); ++attempt) {
+		if (ProbeStateSchema(conn, catalog_name, state.state_schema)) {
+			StateSchemaCacheRemember(cache_key);
+			return;
 		}
-	} catch (...) {
+		ExecuteChecked(conn, "BEGIN TRANSACTION");
 		try {
-			ExecuteChecked(conn, "ROLLBACK");
+			auto create_schema = conn.Query("CREATE SCHEMA IF NOT EXISTS " + MetadataDatabase(catalog_name) + "." +
+			                                QuoteIdentifier(state.state_schema));
+			if (postgres) {
+				ThrowIfQueryFailed(create_schema);
+			}
+			const bool use_state_schema = create_schema && !create_schema->HasError();
+			ExecuteChecked(conn, ConsumersDdl(catalog_name, use_state_schema, state.state_schema));
+			ExecuteChecked(conn, ConsumerSubscriptionsDdl(catalog_name, use_state_schema, state.state_schema));
+			ExecuteChecked(conn, AuditDdl(catalog_name, use_state_schema, state.state_schema));
+			InstallPostgresSnapshotNotifyBestEffort(conn, catalog_name);
+			ExecuteChecked(conn, "COMMIT");
+			if (use_state_schema) {
+				// Pre-warm the StateSchemaExists cache only after the DDL is
+				// committed and visible to other DatabaseInstance connections.
+				StateSchemaCacheRemember(cache_key);
+			}
+			return;
 		} catch (...) {
+			try {
+				ExecuteChecked(conn, "ROLLBACK");
+			} catch (...) {
+			}
+			if (!postgres || attempt == 9) {
+				throw;
+			}
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
 		}
-		throw;
 	}
 }
 

--- a/src/ducklake_metadata.cpp
+++ b/src/ducklake_metadata.cpp
@@ -357,6 +357,11 @@ int64_t ResolveSchemaVersion(duckdb::Connection &conn, const std::string &catalo
 }
 
 int64_t CurrentSnapshot(duckdb::Connection &conn, const std::string &catalog_name) {
+	if (MetadataBackendIsPostgres(conn, catalog_name)) {
+		auto result = QueryPostgresMetadata(
+		    conn, catalog_name, "SELECT max(snapshot_id) AS current_snapshot FROM public.ducklake_snapshot");
+		return SingleInt64(*result, "current snapshot");
+	}
 	auto result = conn.Query("SELECT max(snapshot_id) FROM " + MetadataTable(catalog_name, "ducklake_snapshot"));
 	return SingleInt64(*result, "current snapshot");
 }
@@ -590,8 +595,24 @@ std::string SnapshotNotifyChannel(const std::string &catalog_name) {
 }
 
 bool MetadataBackendIsPostgres(duckdb::Connection &conn, const std::string &catalog_name) {
-	auto result = conn.Query("SELECT type FROM duckdb_databases() WHERE database_name = " +
-	                         QuoteLiteral("__ducklake_metadata_" + catalog_name) + " LIMIT 1");
+	// DuckLake keeps its metadata attachment private, so it is not present in
+	// duckdb_databases(). The public DuckLake catalog path records the metadata
+	// backend as `postgres:<dsn>` and is the authoritative discriminator.
+	auto result = conn.Query(
+	    "SELECT type, path FROM duckdb_databases() WHERE database_name = " + QuoteLiteral(catalog_name) + " LIMIT 1");
+	if (result && !result->HasError() && result->RowCount() > 0 && !result->GetValue(0, 0).IsNull() &&
+	    !result->GetValue(1, 0).IsNull()) {
+		const auto type = duckdb::StringUtil::Lower(result->GetValue(0, 0).ToString());
+		const auto path = duckdb::StringUtil::Lower(result->GetValue(1, 0).ToString());
+		if (type == "ducklake" && StartsWith(path, "postgres:")) {
+			return true;
+		}
+	}
+
+	// Keep supporting an explicitly visible metadata attachment for direct
+	// extension tests and non-DuckLake callers.
+	result = conn.Query("SELECT type FROM duckdb_databases() WHERE database_name = " +
+	                    QuoteLiteral("__ducklake_metadata_" + catalog_name) + " LIMIT 1");
 	if (!result || result->HasError() || result->RowCount() == 0 || result->GetValue(0, 0).IsNull()) {
 		return false;
 	}
@@ -600,12 +621,31 @@ bool MetadataBackendIsPostgres(duckdb::Connection &conn, const std::string &cata
 }
 
 std::string PostgresMetadataDsn(duckdb::Connection &conn, const std::string &catalog_name) {
-	auto result = conn.Query("SELECT path FROM duckdb_databases() WHERE database_name = " +
-	                         QuoteLiteral("__ducklake_metadata_" + catalog_name) + " LIMIT 1");
+	auto result = conn.Query(
+	    "SELECT type, path FROM duckdb_databases() WHERE database_name = " + QuoteLiteral(catalog_name) + " LIMIT 1");
+	if (result && !result->HasError() && result->RowCount() > 0 && !result->GetValue(0, 0).IsNull() &&
+	    !result->GetValue(1, 0).IsNull()) {
+		const auto type = duckdb::StringUtil::Lower(result->GetValue(0, 0).ToString());
+		const auto path = result->GetValue(1, 0).ToString();
+		if (type == "ducklake" && StartsWith(duckdb::StringUtil::Lower(path), "postgres:")) {
+			return path.substr(std::string("postgres:").size());
+		}
+	}
+
+	result = conn.Query("SELECT path FROM duckdb_databases() WHERE database_name = " +
+	                    QuoteLiteral("__ducklake_metadata_" + catalog_name) + " LIMIT 1");
 	if (!result || result->HasError() || result->RowCount() == 0 || result->GetValue(0, 0).IsNull()) {
 		return "";
 	}
 	return result->GetValue(0, 0).ToString();
+}
+
+duckdb::unique_ptr<duckdb::MaterializedQueryResult>
+QueryPostgresMetadata(duckdb::Connection &conn, const std::string &catalog_name, const std::string &sql) {
+	auto result = conn.Query("SELECT * FROM postgres_query(" + QuoteLiteral("__ducklake_metadata_" + catalog_name) +
+	                         ", " + QuoteLiteral(sql) + ")");
+	ThrowIfQueryFailed(result);
+	return result;
 }
 
 void PostgresExecuteBestEffort(duckdb::Connection &conn, const std::string &catalog_name, const std::string &sql) {

--- a/src/include/ducklake_metadata.hpp
+++ b/src/include/ducklake_metadata.hpp
@@ -94,6 +94,8 @@ std::string StateTable(duckdb::Connection &conn, const std::string &catalog_name
 std::string SnapshotNotifyChannel(const std::string &catalog_name);
 bool MetadataBackendIsPostgres(duckdb::Connection &conn, const std::string &catalog_name);
 std::string PostgresMetadataDsn(duckdb::Connection &conn, const std::string &catalog_name);
+duckdb::unique_ptr<duckdb::MaterializedQueryResult>
+QueryPostgresMetadata(duckdb::Connection &conn, const std::string &catalog_name, const std::string &sql);
 
 //===--------------------------------------------------------------------===//
 // Snapshot fact lookups

--- a/src/include/ducklake_metadata.hpp
+++ b/src/include/ducklake_metadata.hpp
@@ -87,11 +87,27 @@ void ConfigureCdcInternalConnection(duckdb::Connection &conn);
 
 std::string MetadataDatabase(const std::string &catalog_name);
 std::string MetadataTable(const std::string &catalog_name, const std::string &table_name);
+std::string MetadataTable(duckdb::Connection &conn, const std::string &catalog_name, const std::string &table_name);
 std::string MetadataAttachmentCacheKey(duckdb::Connection &conn, const std::string &catalog_name);
+
+//! Resolved durable identity for one DuckLake attachment. The defaults retain
+//! the original single-lake PostgreSQL layout; cdc_configure can override both
+//! schemas before the first stateful CDC call for an attachment.
+struct CdcCatalogState {
+	std::string catalog_name;
+	std::string attachment_identity;
+	std::string metadata_schema;
+	std::string state_schema;
+};
+
+CdcCatalogState ResolveCdcCatalogState(duckdb::Connection &conn, const std::string &catalog_name);
+CdcCatalogState ConfigureCdcCatalogState(duckdb::Connection &conn, const std::string &catalog_name,
+                                         const std::string &state_schema, const std::string &metadata_schema);
 std::string StateTable(const std::string &catalog_name, const std::string &table_name, bool use_state_schema);
+std::string StateTable(const std::string &catalog_name, const std::string &table_name, const std::string &state_schema);
 bool StateSchemaExists(duckdb::Connection &conn, const std::string &catalog_name);
 std::string StateTable(duckdb::Connection &conn, const std::string &catalog_name, const std::string &table_name);
-std::string SnapshotNotifyChannel(const std::string &catalog_name);
+std::string SnapshotNotifyChannel(duckdb::Connection &conn, const std::string &catalog_name);
 bool MetadataBackendIsPostgres(duckdb::Connection &conn, const std::string &catalog_name);
 std::string PostgresMetadataDsn(duckdb::Connection &conn, const std::string &catalog_name);
 duckdb::unique_ptr<duckdb::MaterializedQueryResult>
@@ -140,9 +156,10 @@ int64_t ResolveSinceStartSnapshot(duckdb::Connection &conn, const std::string &c
 // State-table DDL strings + lazy bootstrap
 //===--------------------------------------------------------------------===//
 
-std::string ConsumersDdl(const std::string &catalog_name, bool use_state_schema);
-std::string ConsumerSubscriptionsDdl(const std::string &catalog_name, bool use_state_schema);
-std::string AuditDdl(const std::string &catalog_name, bool use_state_schema);
+std::string ConsumersDdl(const std::string &catalog_name, bool use_state_schema, const std::string &state_schema);
+std::string ConsumerSubscriptionsDdl(const std::string &catalog_name, bool use_state_schema,
+                                     const std::string &state_schema);
+std::string AuditDdl(const std::string &catalog_name, bool use_state_schema, const std::string &state_schema);
 
 //! Idempotently create the catalog-resident CDC state tables in a DuckLake
 //! catalog. Throws `CDC_INCOMPATIBLE_CATALOG` before any write when the

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -87,7 +87,7 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcConsumerStatsInit(duckdb
 	BootstrapConsumerStateOrThrow(conn, data.catalog_name);
 	const auto current_snapshot = CurrentSnapshot(conn, data.catalog_name);
 	auto oldest_result = conn.Query("SELECT COALESCE(min(snapshot_id), 0) FROM " +
-	                                MetadataTable(data.catalog_name, "ducklake_snapshot"));
+	                                MetadataTable(conn, data.catalog_name, "ducklake_snapshot"));
 	const auto oldest_snapshot = SingleInt64(*oldest_result, "oldest snapshot");
 
 	const auto consumers = StateTable(conn, data.catalog_name, CONSUMERS_TABLE);
@@ -101,7 +101,7 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcConsumerStatsInit(duckdb
 	auto query = std::string("SELECT c.consumer_name, c.consumer_kind, c.consumer_id, c.last_committed_snapshot, "
 	                         "s.snapshot_time, c.owner_token, c.owner_acquired_at, "
 	                         "c.owner_heartbeat_at, c.lease_interval_seconds FROM ") +
-	             consumers + " c LEFT JOIN " + MetadataTable(data.catalog_name, "ducklake_snapshot") +
+	             consumers + " c LEFT JOIN " + MetadataTable(conn, data.catalog_name, "ducklake_snapshot") +
 	             " s ON s.snapshot_id = c.last_committed_snapshot" + where.str() + " ORDER BY c.consumer_name ASC";
 	auto rows = conn.Query(query);
 	if (!rows || rows->HasError()) {
@@ -292,7 +292,7 @@ void AddDoctorRow(RowScanState &state, const std::string &severity, const std::s
 }
 
 bool MetadataSchemaExists(duckdb::Connection &conn, const std::string &catalog_name) {
-	auto direct = conn.Query("SELECT 1 FROM " + MetadataTable(catalog_name, "ducklake_metadata") + " LIMIT 0");
+	auto direct = conn.Query("SELECT 1 FROM " + MetadataTable(conn, catalog_name, "ducklake_metadata") + " LIMIT 0");
 	if (direct && !direct->HasError()) {
 		return true;
 	}
@@ -385,7 +385,7 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcDoctorInit(duckdb::Clien
 
 	const auto current_snapshot = CurrentSnapshot(conn, data.catalog_name);
 	auto oldest_result = conn.Query("SELECT COALESCE(min(snapshot_id), 0) FROM " +
-	                                MetadataTable(data.catalog_name, "ducklake_snapshot"));
+	                                MetadataTable(conn, data.catalog_name, "ducklake_snapshot"));
 	const auto oldest_snapshot = SingleInt64(*oldest_result, "oldest available snapshot");
 
 	std::vector<std::string> consumer_names;

--- a/test/README.md
+++ b/test/README.md
@@ -37,6 +37,8 @@ Run Python smoke probes after `make debug`:
 uv run python e2e/smoke/compat_warning_smoke.py
 uv run python e2e/smoke/lease_multiconn_smoke.py
 uv run python e2e/smoke/cdc_wait_interrupt_smoke.py
+docker compose -f e2e/docker-compose.yml up -d --wait postgres
+uv run --project e2e python e2e/smoke/postgres_state_isolation_smoke.py
 ```
 
 Run the demo CI gates after `make release`:

--- a/test/configuration.test
+++ b/test/configuration.test
@@ -1,0 +1,84 @@
+# name: test/configuration.test
+# group: [test]
+
+# cdc_configure contract and custom state schema
+
+require ducklake_cdc
+
+statement ok
+INSTALL ducklake;
+
+statement ok
+LOAD ducklake;
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/configuration.ducklake' AS configured_lake
+
+query TTT
+CALL cdc_configure(
+  'configured_lake',
+  state_schema := 'configured_lake_cdc',
+  metadata_schema := 'public'
+);
+----
+configured_lake	configured_lake_cdc	public
+
+# Repeating the same mapping is idempotent.
+query TTT
+CALL cdc_configure(
+  'configured_lake',
+  state_schema := 'configured_lake_cdc',
+  metadata_schema := 'public'
+);
+----
+configured_lake	configured_lake_cdc	public
+
+statement ok
+SELECT * FROM cdc_dml_consumer_create('configured_lake', 'ticks');
+
+query I
+SELECT count(*)
+FROM __ducklake_metadata_configured_lake.configured_lake_cdc.__ducklake_cdc_consumers;
+----
+1
+
+statement error
+CALL cdc_configure(
+  'configured_lake',
+  state_schema := 'different_cdc',
+  metadata_schema := 'public'
+);
+----
+configured
+
+statement error
+CALL cdc_configure(
+  'configured_lake',
+  state_schema := 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl',
+  metadata_schema := 'public'
+);
+----
+63
+
+statement ok
+DETACH configured_lake;
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/configuration_late.ducklake' AS late_lake
+
+query I
+SELECT count(*) FROM cdc_list_consumers('late_lake');
+----
+0
+
+statement error
+CALL cdc_configure(
+  'late_lake',
+  state_schema := 'late_lake_cdc',
+  metadata_schema := 'public'
+);
+----
+before the first stateful
+
+statement ok
+DETACH late_lake;

--- a/test/consumer_lifecycle.test
+++ b/test/consumer_lifecycle.test
@@ -96,3 +96,218 @@ FROM cdc_list_consumers('lake')
 WHERE consumer_name = 'items_sink';
 ----
 0
+
+# ---------------------------------------------------------------------------
+# DDL listen progress: inspected DML-only snapshots advance the durable cursor
+# without weakening caller-committed delivery for real DDL.
+# ---------------------------------------------------------------------------
+
+statement ok
+SELECT * FROM cdc_ddl_consumer_create(
+  'lake',
+  'ddl_progress',
+  start_at := 'now'
+);
+
+statement ok
+INSERT INTO lake.items VALUES (3, 'three');
+
+statement ok
+INSERT INTO lake.items VALUES (4, 'four');
+
+statement ok
+INSERT INTO lake.items VALUES (5, 'five');
+
+query I
+SELECT count(*)
+FROM cdc_ddl_changes_listen(
+  'lake',
+  'ddl_progress',
+  timeout_ms := 0,
+  max_snapshots := 1000
+);
+----
+0
+
+query I
+SELECT last_committed_snapshot = (
+  SELECT max(snapshot_id)
+  FROM __ducklake_metadata_lake.ducklake_snapshot
+)
+FROM cdc_list_consumers('lake')
+WHERE consumer_name = 'ddl_progress';
+----
+true
+
+statement ok
+ALTER TABLE lake.items ADD COLUMN tag VARCHAR;
+
+query III
+SELECT count(*),
+       count(*) FILTER (
+         WHERE event_kind = 'altered'
+           AND object_kind = 'table'
+           AND object_name = 'items'
+       ),
+       min(start_snapshot) = max(end_snapshot)
+FROM cdc_ddl_changes_listen(
+  'lake',
+  'ddl_progress',
+  timeout_ms := 0,
+  max_snapshots := 1000
+);
+----
+1	1	true
+
+# Non-empty DDL remains caller-committed.
+query I
+SELECT last_committed_snapshot < (
+  SELECT max(snapshot_id)
+  FROM __ducklake_metadata_lake.ducklake_snapshot
+)
+FROM cdc_list_consumers('lake')
+WHERE consumer_name = 'ddl_progress';
+----
+true
+
+statement ok
+SET VARIABLE ddl_snapshot = (
+  SELECT max(snapshot_id)
+  FROM __ducklake_metadata_lake.ducklake_snapshot
+);
+
+statement ok
+SELECT * FROM cdc_commit(
+  'lake',
+  'ddl_progress',
+  getvariable('ddl_snapshot')
+);
+
+query I
+SELECT count(*)
+FROM cdc_ddl_changes_listen(
+  'lake',
+  'ddl_progress',
+  timeout_ms := 0,
+  max_snapshots := 1000
+);
+----
+0
+
+# A scoped DDL consumer applies the same rule to DDL on unsubscribed objects:
+# advance the irrelevant snapshot, then deliver the first matching DDL.
+statement ok
+CREATE SCHEMA lake.aux;
+
+statement ok
+SELECT * FROM cdc_ddl_consumer_create(
+  'lake',
+  'aux_ddl_progress',
+  schemas := ['aux'],
+  start_at := 'now'
+);
+
+statement ok
+CREATE TABLE lake.main_only(id INTEGER);
+
+query I
+SELECT count(*)
+FROM cdc_ddl_changes_listen(
+  'lake',
+  'aux_ddl_progress',
+  timeout_ms := 0,
+  max_snapshots := 1000
+);
+----
+0
+
+query I
+SELECT last_committed_snapshot = (
+  SELECT max(snapshot_id)
+  FROM __ducklake_metadata_lake.ducklake_snapshot
+)
+FROM cdc_list_consumers('lake')
+WHERE consumer_name = 'aux_ddl_progress';
+----
+true
+
+statement ok
+CREATE TABLE lake.aux.watched(id INTEGER);
+
+query II
+SELECT count(*),
+       count(*) FILTER (
+         WHERE event_kind = 'created'
+           AND object_kind = 'table'
+           AND schema_name = 'aux'
+           AND object_name = 'watched'
+       )
+FROM cdc_ddl_changes_listen(
+  'lake',
+  'aux_ddl_progress',
+  timeout_ms := 0,
+  max_snapshots := 1000
+);
+----
+1	1
+
+# Non-blocking reads use the same durable empty-window progress rule. This is
+# the path used by Atlas's catalogue relay.
+statement ok
+SELECT * FROM cdc_ddl_consumer_create(
+  'lake',
+  'ddl_read_progress',
+  start_at := 'now'
+);
+
+statement ok
+INSERT INTO lake.items VALUES (6, 'six', NULL);
+
+query I
+SELECT count(*)
+FROM cdc_ddl_changes_read(
+  'lake',
+  'ddl_read_progress',
+  max_snapshots := 1000
+);
+----
+0
+
+query I
+SELECT last_committed_snapshot = (
+  SELECT max(snapshot_id)
+  FROM __ducklake_metadata_lake.ducklake_snapshot
+)
+FROM cdc_list_consumers('lake')
+WHERE consumer_name = 'ddl_read_progress';
+----
+true
+
+statement ok
+ALTER TABLE lake.items ADD COLUMN score INTEGER;
+
+query II
+SELECT count(*),
+       count(*) FILTER (
+         WHERE event_kind = 'altered'
+           AND object_kind = 'table'
+           AND object_name = 'items'
+       )
+FROM cdc_ddl_changes_read(
+  'lake',
+  'ddl_read_progress',
+  max_snapshots := 1000
+);
+----
+1	1
+
+# A delivered DDL batch remains caller-committed for read just as for listen.
+query I
+SELECT last_committed_snapshot < (
+  SELECT max(snapshot_id)
+  FROM __ducklake_metadata_lake.ducklake_snapshot
+)
+FROM cdc_list_consumers('lake')
+WHERE consumer_name = 'ddl_read_progress';
+----
+true

--- a/test/version_and_load.test
+++ b/test/version_and_load.test
@@ -15,7 +15,7 @@ require ducklake_cdc
 query I
 SELECT cdc_version();
 ----
-ducklake_cdc 0.6.1
+ducklake_cdc 0.6.2
 
 query I
 SELECT length(cdc_build_revision()) > 0;

--- a/test/version_and_load.test
+++ b/test/version_and_load.test
@@ -15,7 +15,7 @@ require ducklake_cdc
 query I
 SELECT cdc_version();
 ----
-ducklake_cdc 0.6.0
+ducklake_cdc 0.6.1
 
 query I
 SELECT length(cdc_build_revision()) > 0;


### PR DESCRIPTION
Release v0.6.2 was cut from `db3a5b17b63be5316a93ce7fce32dedf97abd186`. This PR fast-forwards `release/0.6` to the released commit because the branch is protected and must be updated through a pull request.