### PR TITLE
Fix DuckDB source ABI mismatch in SQL tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,17 @@ jobs:
           fetch-depth: 1
           submodules: recursive
 
+      - name: Verify DuckDB source matches the release ABI
+        run: |
+          set -euo pipefail
+          version="$(cat .github/duckdb-version)"
+          expected="$(git ls-remote https://github.com/duckdb/duckdb.git "refs/tags/$version" | cut -f1)"
+          actual="$(git -C duckdb rev-parse HEAD)"
+          if [[ -z "$expected" || "$actual" != "$expected" ]]; then
+            echo "::error::DuckDB source $actual does not match $version ($expected). Loading release extensions would be ABI-unsafe."
+            exit 1
+          fi
+
       - name: Install build deps
         run: |
           sudo apt-get update -y -qq


### PR DESCRIPTION
The SQL integration suite segfaults when loading the official DuckLake binary: the DuckDB submodule points to a development commit while `OVERRIDE_GIT_DESCRIBE` labels the host as v1.5.5, bypassing the version check despite different ABIs.

Restore the submodule to the exact v1.5.5 release commit (`d8cdaa33`) and fail CI before compilation if its source pin differs from the configured release tag. This preserves the full SQL test suite and release gates.

Validation: confirmed the previous pin differs from the upstream release tag; CI will rebuild and run the SQL suite, Python probes, and PostgreSQL demo checks against the corrected host.
