### PR TITLE
Preserve DuckDB worker threads during CDC queries

### DIFF
--- a/docs/hazard-log.md
+++ b/docs/hazard-log.md
@@ -475,3 +475,20 @@ go; this file says what can hurt users or maintainers on the way there.
   this boundary: the shared-connection shape surfaced `thread::join failed:
   Invalid argument` in 1/16 attempts while the derived-connection control
   passed 16/16.
+
+### H-023: CDC changed the database-wide thread pool during query execution
+
+- Evidence: Linux main-branch CI run 34041993086 failed consumer creation with
+  `Invalid Error: Invalid argument`; the same source passed PR CI.
+  `ConfigureCdcInternalConnection` executed `SET threads = 1` on every internal
+  connection. DuckDB 1.5.5 implements this as `ThreadsSetting::SetGlobal`, which
+  calls `TaskScheduler::SetThreads`; worker-pool resizing can join threads while
+  the outer CDC query is running. The setting is not connection-local.
+- Fix: remove that configuration helper and its callers. CDC inherits the
+  database's configured thread budget and never resizes the worker pool.
+  Applications needing a serial CDC instance must configure it before queries
+  start. Do not restore the setting around a call: that also resizes the pool.
+- Regression: `consumer_lifecycle.test` explicitly configures four threads before
+  consumer creation and asserts the setting remains four afterward.
+- This corrects an extension-owned scheduler mutation. It does not establish
+  that every previously reported H-022 symptom has the same cause.

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -709,7 +709,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcConfigureInit(duckdb::Cl
 	auto result = duckdb::make_uniq<RowScanState>();
 	auto &data = input.bind_data->Cast<CdcConfigureData>();
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, data.catalog_name);
 	const auto configured = ConfigureCdcCatalogState(conn, data.catalog_name, data.state_schema, data.metadata_schema);
 	result->rows.push_back({duckdb::Value(configured.catalog_name), duckdb::Value(configured.state_schema),
@@ -1115,7 +1114,6 @@ std::vector<duckdb::Value> CreateConsumerOnce(duckdb::ClientContext &context, co
 	// Windows MinGW's `LockFileEx` / `ERROR_POSSIBLE_DEADLOCK` path
 	// (H-022 in `docs/hazard-log.md`).
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, data.catalog_name);
 	BootstrapConsumerStateOrThrow(conn, data.catalog_name);
 	const auto consumers = StateTable(conn, data.catalog_name, CONSUMERS_TABLE);
@@ -1309,7 +1307,6 @@ duckdb::unique_ptr<duckdb::FunctionData> ConsumerResetBind(duckdb::ClientContext
 std::vector<duckdb::Value> ResetConsumer(duckdb::ClientContext &context, const ConsumerResetData &data) {
 	// Single-connection chain — see CreateConsumer for the H-022 rationale.
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, data.catalog_name);
 	BootstrapConsumerStateOrThrow(conn, data.catalog_name);
 	const auto consumers = StateTable(conn, data.catalog_name, CONSUMERS_TABLE);
@@ -1377,7 +1374,6 @@ duckdb::unique_ptr<duckdb::FunctionData> ConsumerDropBind(duckdb::ClientContext 
 std::vector<duckdb::Value> DropConsumer(duckdb::ClientContext &context, const ConsumerDropData &data) {
 	// Single-connection chain — see CreateConsumer for the H-022 rationale.
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, data.catalog_name);
 	BootstrapConsumerStateOrThrow(conn, data.catalog_name);
 	const auto consumers = StateTable(conn, data.catalog_name, CONSUMERS_TABLE);
@@ -1440,7 +1436,6 @@ duckdb::unique_ptr<duckdb::FunctionData> ConsumerForceReleaseBind(duckdb::Client
 std::vector<duckdb::Value> ForceReleaseConsumer(duckdb::ClientContext &context, const ConsumerForceReleaseData &data) {
 	// Single-connection chain — see CreateConsumer for the H-022 rationale.
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, data.catalog_name);
 	BootstrapConsumerStateOrThrow(conn, data.catalog_name);
 	const auto consumers = StateTable(conn, data.catalog_name, CONSUMERS_TABLE);
@@ -1506,7 +1501,6 @@ duckdb::unique_ptr<duckdb::FunctionData> ConsumerReleaseBind(duckdb::ClientConte
 
 std::vector<duckdb::Value> ReleaseConsumer(duckdb::ClientContext &context, const ConsumerReleaseData &data) {
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, data.catalog_name);
 	BootstrapConsumerStateOrThrow(conn, data.catalog_name);
 	const auto cached_token = CachedToken(context, conn, data.catalog_name, data.consumer_name);
@@ -2118,7 +2112,6 @@ std::vector<duckdb::Value> CommitWindowWithConnection(duckdb::ClientContext &con
 
 std::vector<duckdb::Value> CommitWindow(duckdb::ClientContext &context, const CdcCommitData &data) {
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	return CommitWindowWithConnection(context, conn, data);
 }
 
@@ -2168,7 +2161,6 @@ duckdb::unique_ptr<duckdb::FunctionData> ConsumerHeartbeatBind(duckdb::ClientCon
 
 std::vector<duckdb::Value> HeartbeatConsumer(duckdb::ClientContext &context, const ConsumerHeartbeatData &data) {
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, data.catalog_name);
 	const auto consumers = StateTable(conn, data.catalog_name, CONSUMERS_TABLE);
 	const auto cached_token = CachedToken(context, conn, data.catalog_name, data.consumer_name);
@@ -2923,7 +2915,6 @@ WaitForNextSnapshotWithSubscriptions(duckdb::ClientContext &context, duckdb::Con
 
 std::vector<duckdb::Value> WaitForNextSnapshot(duckdb::ClientContext &context, const ListenWaitData &data) {
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	const auto subscriptions = LoadConsumerSubscriptions(conn, data.catalog_name, data.consumer_name);
 	return WaitForNextSnapshotWithSubscriptions(context, conn, data.catalog_name, data.consumer_name, data.timeout_ms,
 	                                            subscriptions, data.poll_min_ms);
@@ -3009,7 +3000,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> ConsumerListInit(duckdb::Cl
 	auto &data = input.bind_data->Cast<ConsumerListData>();
 	// Single-connection chain — see CreateConsumer for the H-022 rationale.
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, data.catalog_name);
 	BootstrapConsumerStateOrThrow(conn, data.catalog_name);
 	// SELECT order:
@@ -3157,7 +3147,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> ConsumerSubscriptionsInit(d
 	auto &data = input.bind_data->Cast<ConsumerSubscriptionsData>();
 	// Single-connection chain — see CreateConsumer for the H-022 rationale.
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, data.catalog_name);
 	BootstrapConsumerStateOrThrow(conn, data.catalog_name);
 	for (const auto &sub : LoadConsumerSubscriptions(conn, data.catalog_name, data.consumer_name)) {
@@ -3644,7 +3633,6 @@ std::vector<duckdb::Value> ReadWindowWithConnection(duckdb::ClientContext &conte
 
 std::vector<duckdb::Value> ReadWindow(duckdb::ClientContext &context, const CdcWindowData &data) {
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	return ReadWindowWithConnection(context, conn, data);
 }
 
@@ -3733,7 +3721,6 @@ void MaybeCoalesceConsumerListen(duckdb::ClientContext &context, const std::stri
                                  const std::string &consumer_name, const std::string &stream_key, int64_t timeout_ms,
                                  int64_t max_snapshots, int64_t first_matching_snapshot) {
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	MaybeCoalesceConsumerListenWithConnection(context, conn, catalog_name, consumer_name, stream_key, timeout_ms,
 	                                          max_snapshots, first_matching_snapshot);
 }

--- a/src/ddl.cpp
+++ b/src/ddl.cpp
@@ -1324,7 +1324,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcDdlInit(duckdb::ClientCo
 	}
 
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	if (data.ticks) {
 		AppendDdlTickRows(conn, data.catalog_name, data.consumer_name, start_snapshot, end_snapshot, subscriptions,
 		                  nullptr, result->rows, true);
@@ -1511,7 +1510,6 @@ duckdb::unique_ptr<duckdb::FunctionData> CdcRangeDdlBind(duckdb::ClientContext &
 	result->table_names = DdlStringListNamedParameter(input, "table_names");
 	result->table_ids = DdlInt64ListNamedParameter(input, "table_ids");
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, result->catalog_name);
 	result->to_snapshot = RangeDdlToSnapshotParameter(conn, input, result->catalog_name, 2);
 	ValidateDdlRangeBounds(conn, result->catalog_name, result->from_snapshot, result->to_snapshot);
@@ -1529,7 +1527,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcRangeDdlInit(duckdb::Cli
 	auto result = duckdb::make_uniq<RowScanState>();
 	auto &data = input.bind_data->Cast<CdcRangeDdlData>();
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	ExtractDdlRows(conn, data.catalog_name, data.from_snapshot, data.to_snapshot, std::string(), result->rows);
 	const auto filter = BuildDdlQueryFilter(conn, data);
 	ApplyDdlQueryFilter(result->rows, filter);
@@ -1551,7 +1548,6 @@ duckdb::unique_ptr<duckdb::FunctionData> DdlTicksQueryBind(duckdb::ClientContext
 	result->table_names = DdlStringListNamedParameter(input, "table_names");
 	result->table_ids = DdlInt64ListNamedParameter(input, "table_ids");
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, result->catalog_name);
 	result->to_snapshot = input.inputs.size() > 2 && !input.inputs[2].IsNull()
 	                          ? input.inputs[2].GetValue<int64_t>()
@@ -1578,7 +1574,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> DdlTicksQueryInit(duckdb::C
 	auto result = duckdb::make_uniq<RowScanState>();
 	auto &data = input.bind_data->Cast<CdcRangeDdlData>();
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	const std::vector<ConsumerSubscriptionRow> no_subscriptions;
 	const auto filter = BuildDdlQueryFilter(conn, data);
 	const auto *filter_ptr = filter.Empty() ? nullptr : &filter;
@@ -1686,7 +1681,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcSchemaDiffInit(duckdb::C
 	auto &data = input.bind_data->Cast<CdcSchemaDiffData>();
 
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	const auto target_ids =
 	    ResolveTableIdsForFilter(conn, data.catalog_name, data.table_filter, data.from_snapshot, data.to_snapshot);
 	if (target_ids.empty()) {

--- a/src/dml.cpp
+++ b/src/dml.cpp
@@ -340,7 +340,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> DmlTicksInit(duckdb::Client
 	auto &data = input.bind_data->Cast<DmlTicksData>();
 	auto max_snapshots = data.max_snapshots;
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	const auto subscriptions = LoadDmlConsumerSubscriptions(conn, data.catalog_name, data.consumer_name);
 	if (data.listen && !data.explicit_window) {
 		auto ready = WaitForDmlConsumerSnapshot(context, conn, data.catalog_name, data.consumer_name, data.timeout_ms,
@@ -739,7 +738,6 @@ duckdb::unique_ptr<duckdb::FunctionData> CdcChangesBindBase(duckdb::ClientContex
 	// single-reader lease keeps this as a strictly producer/consumer race;
 	// fixing it would require rebinding on every Init.
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, result->catalog_name);
 	const auto subscriptions = LoadConsumerSubscriptions(conn, result->catalog_name, result->consumer_name);
 	ResolveSubscribedTable(subscriptions, result->consumer_name, result->schema_id, result->table_id,
@@ -863,7 +861,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcChangesInit(duckdb::Clie
 	auto &data = input.bind_data->Cast<CdcChangesData>();
 	auto max_snapshots = data.max_snapshots;
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	const auto subscriptions = data.listen && !data.explicit_window
 	                               ? LoadDmlConsumerSubscriptions(conn, data.catalog_name, data.consumer_name)
 	                               : std::vector<ConsumerSubscriptionRow>();
@@ -1056,7 +1053,6 @@ duckdb::unique_ptr<duckdb::FunctionData> DmlTicksQueryBind(duckdb::ClientContext
 	result->table_ids = Int64ListNamedParameter(input, "table_ids");
 	result->table_names = StringListNamedParameter(input, "table_names");
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, result->catalog_name);
 	result->to_snapshot = RangeToSnapshotParameter(conn, input, result->catalog_name, 2);
 	ValidateRangeBounds(conn, result->catalog_name, result->from_snapshot, result->to_snapshot, "cdc_dml_ticks_query");
@@ -1069,7 +1065,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> DmlTicksQueryInit(duckdb::C
 	auto result = duckdb::make_uniq<RowScanState>();
 	auto &data = input.bind_data->Cast<DmlTicksData>();
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	std::unordered_set<int64_t> filter_table_ids(data.table_ids.begin(), data.table_ids.end());
 	for (const auto &table_name_input : data.table_names) {
 		auto table_name = table_name_input.find('.') == std::string::npos ? std::string("main.") + table_name_input
@@ -1127,7 +1122,6 @@ duckdb::unique_ptr<duckdb::FunctionData> CdcRangeChangesBind(duckdb::ClientConte
 	result->catalog_name = GetStringArg(input.inputs[0], "catalog");
 	result->from_snapshot = input.inputs[1].GetValue<int64_t>();
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	CheckCatalogOrThrow(conn, result->catalog_name);
 	result->to_snapshot = RangeToSnapshotParameter(conn, input, result->catalog_name, 2);
 	ValidateRangeBounds(conn, result->catalog_name, result->from_snapshot, result->to_snapshot,
@@ -1199,7 +1193,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcRangeChangesInit(duckdb:
 	auto result = duckdb::make_uniq<RowScanState>();
 	auto &data = input.bind_data->Cast<CdcRangeChangesData>();
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 
 	std::ostringstream column_list;
 	column_list << "tc.snapshot_id, tc.rowid, tc.change_type";

--- a/src/ducklake_metadata.cpp
+++ b/src/ducklake_metadata.cpp
@@ -176,15 +176,6 @@ std::string GenerateUuid(duckdb::Connection &conn) {
 	return result->GetValue(0, 0).ToString();
 }
 
-void ConfigureCdcInternalConnection(duckdb::Connection &conn) {
-	// CDC internal connections execute short metadata lookups and materialize
-	// table-function results. Letting DuckDB parallelize those queries can make
-	// one logical consumer occupy most of the postgres-scanner connection pool.
-	// Keep the internal work serial; user analytical queries still use the
-	// caller's configured thread count.
-	ExecuteChecked(conn, "SET threads = 1");
-}
-
 //===--------------------------------------------------------------------===//
 // Catalog table-name builders + state-schema introspection
 //===--------------------------------------------------------------------===//

--- a/src/include/ducklake_metadata.hpp
+++ b/src/include/ducklake_metadata.hpp
@@ -79,7 +79,6 @@ int64_t SingleInt64(duckdb::MaterializedQueryResult &result, const std::string &
 void ThrowIfQueryFailed(const duckdb::unique_ptr<duckdb::MaterializedQueryResult> &result);
 void ExecuteChecked(duckdb::Connection &conn, const std::string &sql);
 std::string GenerateUuid(duckdb::Connection &conn);
-void ConfigureCdcInternalConnection(duckdb::Connection &conn);
 
 //===--------------------------------------------------------------------===//
 // Catalog table-name builders + state-schema introspection

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -83,7 +83,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcConsumerStatsInit(duckdb
 	auto &data = input.bind_data->Cast<CdcConsumerStatsData>();
 	// Single-connection chain — see CreateConsumer for the H-022 rationale.
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	BootstrapConsumerStateOrThrow(conn, data.catalog_name);
 	const auto current_snapshot = CurrentSnapshot(conn, data.catalog_name);
 	auto oldest_result = conn.Query("SELECT COALESCE(min(snapshot_id), 0) FROM " +
@@ -239,7 +238,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcAuditEventsInit(duckdb::
 	auto &data = input.bind_data->Cast<CdcAuditEventsData>();
 	// Single-connection chain — see CreateConsumer for the H-022 rationale.
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 	BootstrapConsumerStateOrThrow(conn, data.catalog_name);
 	const auto audit = StateTable(conn, data.catalog_name, AUDIT_TABLE);
 	std::ostringstream where;
@@ -365,7 +363,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> CdcDoctorInit(duckdb::Clien
 	auto result = duckdb::make_uniq<RowScanState>();
 	auto &data = input.bind_data->Cast<CdcDoctorData>();
 	duckdb::Connection conn(*context.db);
-	ConfigureCdcInternalConnection(conn);
 
 	if (!MetadataSchemaExists(conn, data.catalog_name)) {
 		AddDoctorRow(*result, "error", "CDC_INCOMPATIBLE_CATALOG", duckdb::Value(),

--- a/test/consumer_lifecycle.test
+++ b/test/consumer_lifecycle.test
@@ -24,6 +24,12 @@ CREATE TABLE lake.items(id INTEGER, payload VARCHAR);
 statement ok
 INSERT INTO lake.items VALUES (1, 'one'), (2, 'two');
 
+# CDC must not resize the database-wide worker pool from inside a query.
+# This used to overwrite the caller's threads setting and intermittently fail
+# with a thread-join error during consumer creation.
+statement ok
+SET threads = 4;
+
 statement ok
 SELECT * FROM cdc_dml_consumer_create(
   'lake',
@@ -31,6 +37,11 @@ SELECT * FROM cdc_dml_consumer_create(
   table_name := 'items',
   start_at := 'beginning'
 );
+
+query I
+SELECT current_setting('threads');
+----
+4
 
 statement ok
 SELECT * FROM cdc_ddl_consumer_create(


### PR DESCRIPTION
CDC's internal connection setup executed `SET threads = 1` on every call. DuckDB implements that setting globally, so consumer creation resized the shared worker pool during an active query. Main-branch CI failed intermittently with `Invalid Error: Invalid argument` even though the same source passed PR CI.

Remove the helper and all callers. CDC now preserves the application's thread budget. Add a SQL regression that sets four threads, creates a consumer, and asserts the setting stays four; document the scheduler mutation separately from previously suspected catalog-lock failures.

Validation: the regression fails against the old binary (threads becomes one). The corrected native extension builds successfully and passes 100 fresh-database consumer lifecycle iterations with four threads, including create/list/window/release operations. The complete CI suite is running.
